### PR TITLE
Sort dynamically added properties

### DIFF
--- a/VirtoCommerce.CatalogModule.Web.Core/Converters/CatalogConverter.cs
+++ b/VirtoCommerce.CatalogModule.Web.Core/Converters/CatalogConverter.cs
@@ -43,6 +43,7 @@ namespace VirtoCommerce.CatalogModule.Web.Converters
                 //Populate property for property values
                 if (catalog.PropertyValues != null)
                 {
+                    var sort = false;
                     foreach (var propValue in catalog.PropertyValues.Select(x => x.ToWebModel()))
                     {
                         var property = retVal.Properties.FirstOrDefault(x => x.Id == propValue.PropertyId);
@@ -55,8 +56,13 @@ namespace VirtoCommerce.CatalogModule.Web.Converters
                             //Need add dummy property for each value without property
                             property = new webModel.Property(propValue, catalog.Id, moduleModel.PropertyType.Catalog);
                             retVal.Properties.Add(property);
+                            sort = true;
                         }
                         property.Values.Add(propValue);
+                    }
+                    if (sort)
+                    {
+                        retVal.Properties = retVal.Properties.OrderBy(x => x.Name).ToList();
                     }
                 }
             }

--- a/VirtoCommerce.CatalogModule.Web.Core/Converters/CategoryConverter.cs
+++ b/VirtoCommerce.CatalogModule.Web.Core/Converters/CategoryConverter.cs
@@ -70,6 +70,7 @@ namespace VirtoCommerce.CatalogModule.Web.Converters
                 //Populate property values
                 if (category.PropertyValues != null)
                 {
+                    var sort = false;
                     foreach (var propValue in category.PropertyValues.Select(x => x.ToWebModel()))
                     {
                         var property = retVal.Properties.FirstOrDefault(x => x.Id == propValue.PropertyId);
@@ -82,8 +83,13 @@ namespace VirtoCommerce.CatalogModule.Web.Converters
                             //Need add dummy property for each value without property
                             property = new webModel.Property(propValue, category.CatalogId, moduleModel.PropertyType.Category);
                             retVal.Properties.Add(property);
+                            sort = true;
                         }
                         property.Values.Add(propValue);
+                    }
+                    if (sort)
+                    {
+                        retVal.Properties = retVal.Properties.OrderBy(x => x.Name).ToList();
                     }
                 }
             }

--- a/VirtoCommerce.CatalogModule.Web.Core/Converters/ProductConverter.cs
+++ b/VirtoCommerce.CatalogModule.Web.Core/Converters/ProductConverter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Omu.ValueInjecter;
 using VirtoCommerce.Platform.Core.Assets;
@@ -134,6 +135,7 @@ namespace VirtoCommerce.CatalogModule.Web.Converters
             //Populate property values
             if (product.PropertyValues != null)
             {
+                var sort = false;
                 foreach (var propValue in product.PropertyValues.Select(x => x.ToWebModel()))
                 {
                     var property = retVal.Properties.FirstOrDefault(x => x.Id == propValue.PropertyId);
@@ -146,8 +148,13 @@ namespace VirtoCommerce.CatalogModule.Web.Converters
                         //Need add dummy property for each value without property
                         property = new webModel.Property(propValue, product.CatalogId, moduleModel.PropertyType.Product);
                         retVal.Properties.Add(property);
+                        sort = true;
                     }
                     property.Values.Add(propValue);
+                }
+                if (sort)
+                {
+                    retVal.Properties = retVal.Properties.OrderBy(x => x.Name).ToList();
                 }
             }
 


### PR DESCRIPTION
When properties of catalogs, categories and products don't have a property definition, the values are added at end of the list. The user however expects the properties to be ordered alphabetically.