### PR TITLE
Fixed product search within Categories.

### DIFF
--- a/VirtoCommerce.CatalogModule.Data/Search/SearchCriteriaExtensions.cs
+++ b/VirtoCommerce.CatalogModule.Data/Search/SearchCriteriaExtensions.cs
@@ -22,26 +22,8 @@ namespace VirtoCommerce.CatalogModule.Data.Search
 
         public static IList<string> GetOutlines(this CatalogSearchCriteriaBase criteria)
         {
-            
-            var rawOutlines = criteria.GetRawOutlines();
-            var result = new List<string>(rawOutlines.Count);
-            foreach (var rawOutline in rawOutlines)
-            {
-                var outlineParts = rawOutline.Split('/').ToList();
-                // Add the catalog to the outline if it is not present.
-                if (!outlineParts.First().Equals(criteria.CatalogId))
-                {
-                    outlineParts.Insert(0, criteria.CatalogId);
-                }
-
-                var outline = StringsHelper.JoinNonEmptyStrings("/", outlineParts.ToArray()).ToLowerInvariant();
-                if (!result.Contains(outline))
-                {
-                    result.Add(outline);
-                }
-            }
-
-            return result;
+            return Web.Converters.OutlineHelper
+                .EnsurePhysicalOutline(criteria.GetRawOutlines(), criteria.CatalogId);
         }
 
         public static IList<string> GetRawOutlines(this CatalogSearchCriteriaBase criteria)

--- a/VirtoCommerce.CatalogModule.Data/Search/SearchCriteriaExtensions.cs
+++ b/VirtoCommerce.CatalogModule.Data/Search/SearchCriteriaExtensions.cs
@@ -22,11 +22,24 @@ namespace VirtoCommerce.CatalogModule.Data.Search
 
         public static IList<string> GetOutlines(this CatalogSearchCriteriaBase criteria)
         {
-            var result = criteria
-                .GetRawOutlines()
-                .Select(outline => StringsHelper.JoinNonEmptyStrings("/", criteria.CatalogId, outline).ToLowerInvariant())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
+            
+            var rawOutlines = criteria.GetRawOutlines();
+            var result = new List<string>(rawOutlines.Count);
+            foreach (var rawOutline in rawOutlines)
+            {
+                var outlineParts = rawOutline.Split('/').ToList();
+                // Add the catalog to the outline if it is not present.
+                if (!outlineParts.First().Equals(criteria.CatalogId))
+                {
+                    outlineParts.Insert(0, criteria.CatalogId);
+                }
+
+                var outline = StringsHelper.JoinNonEmptyStrings("/", outlineParts.ToArray()).ToLowerInvariant();
+                if (!result.Contains(outline))
+                {
+                    result.Add(outline);
+                }
+            }
 
             return result;
         }

--- a/VirtoCommerce.CatalogModule.Data/Services/CatalogSearchServiceDecorator.cs
+++ b/VirtoCommerce.CatalogModule.Data/Services/CatalogSearchServiceDecorator.cs
@@ -54,7 +54,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
                 serviceCriteria.ObjectType = KnownDocumentTypes.Product;
                 serviceCriteria.SearchPhrase = criteria.Keyword;
                 serviceCriteria.CatalogId = criteria.CatalogId;
-                serviceCriteria.Outline = criteria.Outline;
+                serviceCriteria.Outline = criteria.Outline ?? criteria.CategoryId;
                 serviceCriteria.WithHidden = criteria.WithHidden;
                 serviceCriteria.Skip = criteria.Skip;
                 serviceCriteria.Take = criteria.Take;

--- a/VirtoCommerce.CatalogModule.Data/Services/CatalogSearchServiceDecorator.cs
+++ b/VirtoCommerce.CatalogModule.Data/Services/CatalogSearchServiceDecorator.cs
@@ -54,7 +54,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
                 serviceCriteria.ObjectType = KnownDocumentTypes.Product;
                 serviceCriteria.SearchPhrase = criteria.Keyword;
                 serviceCriteria.CatalogId = criteria.CatalogId;
-                serviceCriteria.Outline = criteria.CategoryId;
+                serviceCriteria.Outline = criteria.Outline;
                 serviceCriteria.WithHidden = criteria.WithHidden;
                 serviceCriteria.Skip = criteria.Skip;
                 serviceCriteria.Take = criteria.Take;

--- a/VirtoCommerce.CatalogModule.Web.Core/Converters/CategoryConverter.cs
+++ b/VirtoCommerce.CatalogModule.Web.Core/Converters/CategoryConverter.cs
@@ -39,7 +39,8 @@ namespace VirtoCommerce.CatalogModule.Web.Converters
             var parents = new List<moduleModel.Category>();
             if (category.Parents != null)
             {
-                retVal.Outline = category.Outlines.FirstOrDefault().ToString();
+                retVal.Outline = OutlineHelper.EnsurePhysicalOutline(category.Outlines, category.CatalogId)
+                    .FirstOrDefault(); //category.Outlines.FirstOrDefault().ToString();
                 retVal.Path = string.Join("/", category.Parents.Select(x => x.Name));
             }
 

--- a/VirtoCommerce.CatalogModule.Web.Core/Converters/CategoryConverter.cs
+++ b/VirtoCommerce.CatalogModule.Web.Core/Converters/CategoryConverter.cs
@@ -39,7 +39,7 @@ namespace VirtoCommerce.CatalogModule.Web.Converters
             var parents = new List<moduleModel.Category>();
             if (category.Parents != null)
             {
-                retVal.Outline = string.Join("/", category.Parents.Select(x => x.Id));
+                retVal.Outline = category.Outlines.FirstOrDefault().ToString();
                 retVal.Path = string.Join("/", category.Parents.Select(x => x.Name));
             }
 

--- a/VirtoCommerce.CatalogModule.Web.Core/Converters/OutlineHelper.cs
+++ b/VirtoCommerce.CatalogModule.Web.Core/Converters/OutlineHelper.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using VirtoCommerce.Domain.Catalog.Model;
+
+namespace VirtoCommerce.CatalogModule.Web.Converters
+{
+    public static class OutlineHelper
+    {
+        public static string[] EnsurePhysicalOutline(ICollection<string> rawOutlines, string catalogId)
+        {
+            var retVal = new List<string>(rawOutlines.Count);
+            foreach (var rawOutline in rawOutlines)
+            {
+                var outlineParts = rawOutline.Split('/').ToList();
+                // Add the catalog to the outline if it is not present.
+                if (!outlineParts.First().Equals(catalogId))
+                {
+                    outlineParts.Insert(0, catalogId);
+                }
+
+                var outline = string.Join("/", outlineParts.ToArray()).ToLowerInvariant();
+                if (!retVal.Contains(outline))
+                {
+                    retVal.Add(outline);
+                }
+            }
+
+            return retVal.ToArray();
+        }
+
+        public static IEnumerable<string> EnsurePhysicalOutline(ICollection<Outline> outlines, string catalogId)
+        {
+            var x = outlines.Select(ol => ol.ToString()).ToArray();
+            return EnsurePhysicalOutline(x, catalogId);
+        }
+    }
+}

--- a/VirtoCommerce.CatalogModule.Web.Core/VirtoCommerce.CatalogModule.Web.Core.csproj
+++ b/VirtoCommerce.CatalogModule.Web.Core/VirtoCommerce.CatalogModule.Web.Core.csproj
@@ -63,6 +63,7 @@
     </Compile>
     <Compile Include="Converters\AggregationConverters.cs" />
     <Compile Include="Converters\OutlineConverter.cs" />
+    <Compile Include="Converters\OutlineHelper.cs" />
     <Compile Include="Converters\PropertyValidationRuleConverter.cs" />
     <Compile Include="Converters\SearchCriteriaConverter.cs" />
     <Compile Include="Converters\AssetConverter.cs" />

--- a/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
+++ b/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
@@ -68,6 +68,9 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
             if ((coreModelCriteria.ResponseGroup & coreModel.SearchResponseGroup.WithCategories) == coreModel.SearchResponseGroup.WithCategories)
             {
                 coreModelCriteria.ResponseGroup = coreModelCriteria.ResponseGroup & ~coreModel.SearchResponseGroup.WithProducts;
+
+                coreModelCriteria.ResponseGroup = coreModelCriteria.ResponseGroup |= coreModel.SearchResponseGroup.WithOutlines;
+
                 var categoriesSearchResult = _searchService.Search(coreModelCriteria);
                 var categoriesTotalCount = categoriesSearchResult.Categories.Count();
 

--- a/VirtoCommerce.CatalogModule.Web/Scripts/blades/categories-items-list.js
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/blades/categories-items-list.js
@@ -72,9 +72,16 @@
             // Search Criteria
             function getSearchCriteria()
             {
+                // Get outline of current Category.
+                var outline = blade.categoryId;
+                if (blade.category != undefined) {
+                    outline = blade.category.outline.join('/');
+                }
+
                 var searchCriteria = {
                     catalogId: blade.catalogId,
                     categoryId: blade.categoryId,
+                    outline: outline,
                     keyword: filter.keyword ? filter.keyword : undefined,
                     responseGroup: 'withCategories, withProducts',
                     sort: uiGridHelper.getSortExpression($scope),


### PR DESCRIPTION
The product search doesn't work anymore after the change of Outlines to use Codes instead of Id's.
When searching, the id was still used to query instead of the outline.

* Assured outlines are fetched and sent to browser
* Assured outline is sent back on search
* Fixed issue where Catalog was added twice in SearchCriteriaExtensions.GetOutlines
