### PR TITLE
174: added infinite scrolling for dictionary property values

### DIFF
--- a/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-dictionary-list.js
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-dictionary-list.js
@@ -66,7 +66,7 @@ angular.module('virtoCommerce.catalogModule')
         // ui-grid
         $scope.setGridOptions = function (gridOptions) {
             uiGridHelper.initialize($scope, gridOptions, function (gridApi) {
-                if ($scope.gridApi.core) {
+                if (gridApi && gridApi.core) {
                     uiGridHelper.bindRefreshOnSortChanged($scope);
                 }
             });

--- a/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-list.js
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-list.js
@@ -62,12 +62,16 @@ angular.module('virtoCommerce.catalogModule')
 			bladeNavigationService.showBlade(newBlade, blade);
 		}
 
-        $scope.getPropValues = function (propId, keyword) {
-            //TODO: Replace to lazy loading and infinite scroll
-            return propDictItems.search({ propertyIds: [propId], searchPhrase: keyword, take : 10000 }).$promise.then(function (result) {
-				return result;
-			});
-		};
+        $scope.getPropValues = function (propId, keyword, countToSkip, countToTake) {
+            return propDictItems.search({
+                propertyIds: [propId],
+                searchPhrase: keyword,
+                skip: countToSkip,
+                take: countToTake
+            }).$promise.then(function(result) {
+                return result;
+            });
+        };
 
 		var formScope;
 		$scope.setForm = function (form) {

--- a/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.js
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.js
@@ -128,11 +128,10 @@ angular.module('virtoCommerce.catalogModule')
 
                 return scope.getPropValues()(scope.currentEntity.id, '', countToSkip, countToTake).then(function (result) {
                     populateDictionaryValues(result.results);
+                    $select.page++;
 
                     // If there are more items to display, let's prepare to handle these items.
                     if (scope.context.allDictionaryValues.length < result.totalCount) {
-                        $select.page++;
-
                         // Reset scrolling for the when-scrolled directive, so it could trigger this method for next page.
                         scope.$broadcast('scrollCompleted');
                     }

--- a/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.js
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.js
@@ -126,7 +126,7 @@ angular.module('virtoCommerce.catalogModule')
                 var countToSkip = $select.page * scope.pageSize;
                 var countToTake = scope.pageSize;
 
-                return scope.getPropValues()(scope.currentEntity.id, '', countToSkip, countToTake).then(function (result) {
+                return scope.getPropValues()(scope.currentEntity.id, $select.search, countToSkip, countToTake).then(function (result) {
                     populateDictionaryValues(result.results);
                     $select.page++;
 

--- a/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.js
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.js
@@ -10,22 +10,21 @@ angular.module('virtoCommerce.catalogModule')
         scope: {
             languages: "=",
             defaultLanguage: "=",
-            pageSize: "=?",
-            getPropValues: "&"
+            getPropValues: "&",
+            pageSize: "@?"
         },
         link: function (scope, element, attr, ctrls, linker) {
             var ngModelController = ctrls[1];
 
             scope.currentEntity = ngModelController.$modelValue;
 
-            scope.currentPage = 0;
-            scope.pageSize = angular.isDefined(scope.size) ? scope.size : 10;
-
             scope.context = {};
             scope.context.currentPropValues = [];
             scope.context.allDictionaryValues = [];
             scope.context.langValuesMap = {};
             scope.context.form = ctrls[0];
+
+            scope.pageSize = angular.isDefined(scope.pageSize) ? scope.pageSize : 50;
 
             scope.$watch('context.langValuesMap', function (newValue, oldValue) {
                 if (newValue != oldValue) {
@@ -41,7 +40,7 @@ angular.module('virtoCommerce.catalogModule')
 
             scope.$watch('context.currentPropValues', function (newValues) {
                 //reflect only real changes
-                if (isValuesDifferent(newValues, scope.currentEntity.values)) {                   
+                if (isValuesDifferent(newValues, scope.currentEntity.values)) {
 
                     if (newValues[0] === undefined) {
                         scope.currentEntity.values = null;

--- a/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.js
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.js
@@ -145,24 +145,27 @@ angular.module('virtoCommerce.catalogModule')
             function populateDictionaryValues(dictionaryValues) {
                 angular.forEach(dictionaryValues,
                     function(dictItem) {
-                        var dictValue = {
-                            alias: dictItem.alias,
-                            valueId: dictItem.id,
-                            value: dictItem.alias
-                        };
-
-                        //Need to select already selected values. Dictionary values have same type as standard values.
-                        dictValue.selected = angular.isDefined(_.find(scope.currentEntity.values,
+                        // Check if current dictionary value is already selected
+                        var dictValue = _.find(scope.context.currentPropValues,
                             function(item) {
                                 return item.valueId == dictItem.id;
-                            }));
+                            });
+
+                        var valueIsSelected = angular.isDefined(dictValue);
+
+                        // If the value is not selected, create a new item to add it to ui-select
+                        if (!valueIsSelected) {
+                            dictValue = {
+                                alias: dictItem.alias,
+                                valueId: dictItem.id,
+                                value: dictItem.alias
+                            };
+                        }
+
+                        // Need to select already selected values. Dictionary values have same type as standard values.
+                        dictValue.selected = valueIsSelected;
 
                         scope.context.allDictionaryValues.push(dictValue);
-
-                        if (dictValue.selected) {
-                            //add selected value
-                            scope.context.currentPropValues.push(dictValue);
-                        }
                     });
             }
 

--- a/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.tpl.html
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.tpl.html
@@ -137,7 +137,7 @@
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match allow-clear="true" placeholder="{{ 'platform.genericValueInput.placeholders.short-text-dictionary' | translate }}">{{$select.selected.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -147,7 +147,7 @@
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match allow-clear="true" placeholder="{{ 'platform.genericValueInput.placeholders.number' | translate }}">{{$select.selected.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -159,7 +159,7 @@
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match placeholder="{{ 'platform.genericValueInput.placeholders.short-text-dictionary-multivalue' | translate }}">{{$item.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -169,7 +169,7 @@
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match placeholder="{{ 'platform.genericValueInput.placeholders.number-multivalue' | translate }}">{{$item.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -304,7 +304,7 @@
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match allow-clear="true" placeholder="{{ 'platform.genericValueInput.placeholders.short-text-dictionary-multilang' | translate }}">{{$select.selected.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -315,7 +315,7 @@
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match allow-clear="true" placeholder="{{ 'platform.genericValueInput.placeholders.number' | translate }}">{{$select.selected.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -326,7 +326,7 @@
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match placeholder="{{ 'platform.genericValueInput.placeholders.short-text-dictionary-multivalue-multilang' | translate }}">{{$item.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -337,7 +337,7 @@
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match placeholder="{{ 'platform.genericValueInput.placeholders.number-multivalue' | translate }}">{{$item.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>

--- a/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.tpl.html
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.tpl.html
@@ -136,7 +136,7 @@
     <script type="text/ng-template" id="ShortText-dictionary.html">
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
-                <ui-select-match allow-clear="true" placeholder="Select value">{{$select.selected.value}}</ui-select-match>
+                <ui-select-match allow-clear="true" placeholder="{{ 'platform.genericValueInput.placeholders.short-text-dictionary' | translate }}">{{$select.selected.value}}</ui-select-match>
                 <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
@@ -146,7 +146,7 @@
     <script type="text/ng-template" id="Number-dictionary.html">
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
-                <ui-select-match allow-clear="true" placeholder="Select value">{{$select.selected.value}}</ui-select-match>
+                <ui-select-match allow-clear="true" placeholder="{{ 'platform.genericValueInput.placeholders.number' | translate }}">{{$select.selected.value}}</ui-select-match>
                 <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
@@ -158,7 +158,7 @@
     <script type="text/ng-template" id="ShortText-dictionary-multivalue.html">
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
-                <ui-select-match placeholder="Select value">{{$item.value}}</ui-select-match>
+                <ui-select-match placeholder="{{ 'platform.genericValueInput.placeholders.short-text-dictionary-multivalue' | translate }}">{{$item.value}}</ui-select-match>
                 <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
@@ -168,7 +168,7 @@
     <script type="text/ng-template" id="Number-dictionary-multivalue.html">
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
-                <ui-select-match placeholder="Select value">{{$item.value}}</ui-select-match>
+                <ui-select-match placeholder="{{ 'platform.genericValueInput.placeholders.number-multivalue' | translate }}">{{$item.value}}</ui-select-match>
                 <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
@@ -303,7 +303,7 @@
     <script type="text/ng-template" id="ShortText-dictionary-multilang.html">
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
-                <ui-select-match allow-clear="true" placeholder="Select value">{{$select.selected.value}}</ui-select-match>
+                <ui-select-match allow-clear="true" placeholder="{{ 'platform.genericValueInput.placeholders.short-text-dictionary-multilang' | translate }}">{{$select.selected.value}}</ui-select-match>
                 <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
@@ -314,7 +314,7 @@
     <script type="text/ng-template" id="Number-dictionary-multilang.html">
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
-                <ui-select-match allow-clear="true" placeholder="Select value">{{$select.selected.value}}</ui-select-match>
+                <ui-select-match allow-clear="true" placeholder="{{ 'platform.genericValueInput.placeholders.number' | translate }}">{{$select.selected.value}}</ui-select-match>
                 <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
@@ -325,7 +325,7 @@
     <script type="text/ng-template" id="ShortText-dictionary-multivalue-multilang.html">
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
-                <ui-select-match placeholder="Select value">{{$item.value}}</ui-select-match>
+                <ui-select-match placeholder="{{ 'platform.genericValueInput.placeholders.short-text-dictionary-multivalue-multilang' | translate }}">{{$item.value}}</ui-select-match>
                 <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
@@ -336,7 +336,7 @@
     <script type="text/ng-template" id="Number-dictionary-multivalue-multilang.html">
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
-                <ui-select-match placeholder="Select value">{{$item.value}}</ui-select-match>
+                <ui-select-match placeholder="{{ 'platform.genericValueInput.placeholders.number-multivalue' | translate }}">{{$item.value}}</ui-select-match>
                 <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>

--- a/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.tpl.html
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.tpl.html
@@ -137,7 +137,7 @@
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match allow-clear="true" placeholder="Select value">{{$select.selected.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -147,7 +147,7 @@
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match allow-clear="true" placeholder="Select value">{{$select.selected.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -159,7 +159,7 @@
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match placeholder="Select value">{{$item.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -169,7 +169,7 @@
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match placeholder="Select value">{{$item.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -304,7 +304,7 @@
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match allow-clear="true" placeholder="Select value">{{$select.selected.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -315,7 +315,7 @@
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match allow-clear="true" placeholder="Select value">{{$select.selected.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -326,7 +326,7 @@
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match placeholder="Select value">{{$item.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>
@@ -337,7 +337,7 @@
         <div class="form-input">
             <ui-select multiple ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match placeholder="Select value">{{$item.value}}</ui-select-match>
-                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'">
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>
             </ui-select>

--- a/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.tpl.html
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.tpl.html
@@ -335,7 +335,7 @@
 
     <script type="text/ng-template" id="Number-dictionary-multivalue-multilang.html">
         <div class="form-input">
-            <ui-select multiple ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
+            <ui-select multiple ng-model="context.currentPropValues" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match placeholder="{{ 'platform.genericValueInput.placeholders.number-multivalue' | translate }}">{{$item.value}}</ui-select-match>
                 <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>


### PR DESCRIPTION
Changes made in `va-platform2` directive for #174:
* `getPropValues` function: added `countToSkip` and `countToTake` parameters. They are used for paged parameter loading.
* Added `loadNextDictionaryValues` method which is called by scrolling dictionary value list down. It loads next page of dictionary values (if the backend has more values to send). It is also used internally by `loadDictionaryValues` method which loads first page of values.
* Added optional `page-size` attribute that is used to adjust page size. If it is not specified, `va-property2` will use `50` as a fallback value.
* Modified templates for lists of dictionary values: replaced hard-coded English placeholders by translatable resource strings from `??.VirtoCommerce.Common.json` resources (located in `VirtoCommerce.Platform`).