### PR TITLE
Force parameterized offset query to fix paging issue.

### DIFF
--- a/VirtoCommerce.CatalogModule.Data/Services/PropertyDictionaryItemService.cs
+++ b/VirtoCommerce.CatalogModule.Data/Services/PropertyDictionaryItemService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data.Entity;
 using System.Linq;
 using CacheManager.Core;
 using VirtoCommerce.CatalogModule.Data.Model;
@@ -130,7 +131,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
                     query = query.OrderBySortInfos(sortInfos);
 
                     result.TotalCount = query.Count();
-                    var ids = query.Skip(criteria.Skip).Take(criteria.Take).Select(x => x.Id).ToArray();
+                    var ids = query.Skip(() => criteria.Skip).Take(() => criteria.Take).Select(x => x.Id).ToArray();
                     result.Results = GetByIds(ids).AsQueryable().OrderBySortInfos(sortInfos).ToList();
                     return result;
                 }


### PR DESCRIPTION
When searching for all property dictionary items using the propertyDictionaryItemService, it seems that a combination of sorting and paging on the produced EF query returns unstable (duplicate) results.

This behaviour got introduced when an additional sort was added in commit https://github.com/VirtoCommerce/vc-module-catalog/commit/56fb799d

I was able to mitigate the issue by forcing a parameterized query but the root cause why SQL is returning unstable results is unknown to me.

Reproducible by executing the queries in following file and comparing the result sets:
[EFReproductionQueries.zip](https://github.com/delawarePro/vc-module-catalog/files/2892976/EFReproductionQueries.zip)
