### PR TITLE
#221 Product indexed search gives unexpected order when we are using sorting by non-existent index attribute:

### DIFF
--- a/VirtoCommerce.CatalogModule.Data/Search/CategorySearchRequestBuilder.cs
+++ b/VirtoCommerce.CatalogModule.Data/Search/CategorySearchRequestBuilder.cs
@@ -93,6 +93,8 @@ namespace VirtoCommerce.CatalogModule.Data.Search
                     case "title":
                         result.Add(new SortingField("name", isDescending));
                         break;
+                    case "manual":
+                        break;
                     default:
                         result.Add(new SortingField(fieldName, isDescending));
                         break;


### PR DESCRIPTION
- Added "manual" field handling (corresponds to "Featured" on storefront);