### PR TITLE
Extract variations loading to separate virtual method and add links

### DIFF
--- a/VirtoCommerce.CatalogModule.Data/Repositories/CatalogRepositoryImpl.cs
+++ b/VirtoCommerce.CatalogModule.Data/Repositories/CatalogRepositoryImpl.cs
@@ -692,6 +692,11 @@ namespace VirtoCommerce.CatalogModule.Data.Repositories
                     {
                         var variationEditorialReviews = EditorialReviews.Where(x => variationIds.Contains(x.ItemId)).ToArray();
                     }
+
+                    if (respGroup.HasFlag(ItemResponseGroup.Links))
+                    {
+                        var variationLinks = CategoryItemRelations.Where(x => variationIds.Contains(x.ItemId)).ToArray();
+                    }
                 }
             }
         }

--- a/VirtoCommerce.CatalogModule.Data/Repositories/CatalogRepositoryImpl.cs
+++ b/VirtoCommerce.CatalogModule.Data/Repositories/CatalogRepositoryImpl.cs
@@ -666,7 +666,7 @@ namespace VirtoCommerce.CatalogModule.Data.Repositories
         }
         #endregion
 
-        protected virtual void LoadVariationsByParentIds(IEnumerable<string> parentIds, ItemResponseGroup respGroup)
+        protected virtual void LoadVariationsByParentIds(string[] parentIds, ItemResponseGroup respGroup)
         {
             // TODO: Call GetItemByIds for variations recursively (need to measure performance and data amount first)
 

--- a/VirtoCommerce.CatalogModule.Data/Repositories/CatalogRepositoryImpl.cs
+++ b/VirtoCommerce.CatalogModule.Data/Repositories/CatalogRepositoryImpl.cs
@@ -279,32 +279,7 @@ namespace VirtoCommerce.CatalogModule.Data.Repositories
 
                     if (respGroup.HasFlag(coreModel.ItemResponseGroup.Variations))
                     {
-                        // TODO: Call GetItemByIds for variations recursively (need to measure performance and data amount first)
-
-                        var variationIds = Items.Where(x => itemIds.Contains(x.ParentId)).Select(x => x.Id).ToArray();
-
-                        if (!variationIds.IsNullOrEmpty())
-                        {
-                            // Always load info, images and property values for variations
-                            var variations = Items.Include(x => x.Images).Where(x => variationIds.Contains(x.Id)).ToArray();
-
-                            if (variations.Any())
-                            {
-                                variationIds = variations.Select(x => x.Id).ToArray();
-
-                                var variationPropertyValues = PropertyValues.Include(x => x.DictionaryItem.DictionaryItemValues).Where(x => variationIds.Contains(x.ItemId)).ToArray();
-
-                                if (respGroup.HasFlag(ItemResponseGroup.ItemAssets))
-                                {
-                                    var variationAssets = Assets.Where(x => variationIds.Contains(x.ItemId)).ToArray();
-                                }
-
-                                if (respGroup.HasFlag(ItemResponseGroup.ItemEditorialReviews))
-                                {
-                                    var variationEditorialReviews = EditorialReviews.Where(x => variationIds.Contains(x.ItemId)).ToArray();
-                                }
-                            }
-                        }
+                        LoadVariationsByParentIds(itemIds, respGroup);
                     }
 
                     if (respGroup.HasFlag(coreModel.ItemResponseGroup.ItemAssociations))
@@ -690,6 +665,36 @@ namespace VirtoCommerce.CatalogModule.Data.Repositories
             return result;
         }
         #endregion
+
+        protected virtual void LoadVariationsByParentIds(IEnumerable<string> parentIds, ItemResponseGroup respGroup)
+        {
+            // TODO: Call GetItemByIds for variations recursively (need to measure performance and data amount first)
+
+            var variationIds = Items.Where(x => parentIds.Contains(x.ParentId)).Select(x => x.Id).ToArray();
+
+            if (!variationIds.IsNullOrEmpty())
+            {
+                // Always load info, images and property values for variations
+                var variations = Items.Include(x => x.Images).Where(x => variationIds.Contains(x.Id)).ToArray();
+
+                if (variations.Any())
+                {
+                    variationIds = variations.Select(x => x.Id).ToArray();
+
+                    var variationPropertyValues = PropertyValues.Include(x => x.DictionaryItem.DictionaryItemValues).Where(x => variationIds.Contains(x.ItemId)).ToArray();
+
+                    if (respGroup.HasFlag(ItemResponseGroup.ItemAssets))
+                    {
+                        var variationAssets = Assets.Where(x => variationIds.Contains(x.ItemId)).ToArray();
+                    }
+
+                    if (respGroup.HasFlag(ItemResponseGroup.ItemEditorialReviews))
+                    {
+                        var variationEditorialReviews = EditorialReviews.Where(x => variationIds.Contains(x.ItemId)).ToArray();
+                    }
+                }
+            }
+        }
 
         protected virtual void AddBatchDeletedEntities<T>(IList<string> ids)
             where T : Entity, new()


### PR DESCRIPTION
There are some fields missing for variations when they are loaded with parent products, such as Links.

This change adds the links loading for variations and extracts the logic for loading variations to a separate virtual method for better extensibility. 