### PR TITLE
288 - Allow to disable event-based indexation

### DIFF
--- a/VirtoCommerce.CatalogModule.Web/Module.cs
+++ b/VirtoCommerce.CatalogModule.Web/Module.cs
@@ -134,9 +134,7 @@ namespace VirtoCommerce.CatalogModule.Web
             _container.RegisterType<ListEntryMover<Category>, CategoryMover>();
             _container.RegisterType<ListEntryMover<CatalogProduct>, ProductMover>();
 
-            var eventHandlerRegistrar = _container.Resolve<IHandlerRegistrar>();
-            eventHandlerRegistrar.RegisterHandler<ProductChangedEvent>(async (message, token) => await _container.Resolve<IndexProductChangedEventHandler>().Handle(message));
-            eventHandlerRegistrar.RegisterHandler<CategoryChangedEvent>(async (message, token) => await _container.Resolve<IndexCategoryChangedEventHandler>().Handle(message));
+       
         }
 
         public override void PostInitialize()
@@ -189,6 +187,13 @@ namespace VirtoCommerce.CatalogModule.Web
 
             _container.RegisterInstance(categoryIndexingConfiguration.DocumentType, categoryIndexingConfiguration);
 
+            var settingManager = _container.Resolve<ISettingsManager>();
+            if (settingManager.GetValue("Catalog.Search.EventBasedIndexation.Enable", false))
+            {
+                var eventHandlerRegistrar = _container.Resolve<IHandlerRegistrar>();
+                eventHandlerRegistrar.RegisterHandler<ProductChangedEvent>(async (message, token) => await _container.Resolve<IndexProductChangedEventHandler>().Handle(message));
+                eventHandlerRegistrar.RegisterHandler<CategoryChangedEvent>(async (message, token) => await _container.Resolve<IndexCategoryChangedEventHandler>().Handle(message));
+            }
 
             #region Register types for generic Export
 

--- a/VirtoCommerce.CatalogModule.Web/Module.cs
+++ b/VirtoCommerce.CatalogModule.Web/Module.cs
@@ -132,9 +132,7 @@ namespace VirtoCommerce.CatalogModule.Web
 
             _container.RegisterType<IListEntrySearchService, ListEntrySearchService>();
             _container.RegisterType<ListEntryMover<Category>, CategoryMover>();
-            _container.RegisterType<ListEntryMover<CatalogProduct>, ProductMover>();
-
-       
+            _container.RegisterType<ListEntryMover<CatalogProduct>, ProductMover>();       
         }
 
         public override void PostInitialize()
@@ -187,8 +185,8 @@ namespace VirtoCommerce.CatalogModule.Web
 
             _container.RegisterInstance(categoryIndexingConfiguration.DocumentType, categoryIndexingConfiguration);
 
-            var settingManager = _container.Resolve<ISettingsManager>();
-            if (settingManager.GetValue("Catalog.Search.EventBasedIndexation.Enable", false))
+            var settingsManager = _container.Resolve<ISettingsManager>();
+            if (settingsManager.GetValue("Catalog.Search.EventBasedIndexation.Enable", false))
             {
                 var eventHandlerRegistrar = _container.Resolve<IHandlerRegistrar>();
                 eventHandlerRegistrar.RegisterHandler<ProductChangedEvent>(async (message, token) => await _container.Resolve<IndexProductChangedEventHandler>().Handle(message));

--- a/VirtoCommerce.CatalogModule.Web/module.manifest
+++ b/VirtoCommerce.CatalogModule.Web/module.manifest
@@ -119,7 +119,7 @@
                 <name>Catalog.Search.EventBasedIndexation.Enable</name>
                 <valueType>boolean</valueType>
                 <defaultValue>false</defaultValue>
-                <title>Set to True to enable event-based indexation for catalog entities (Restart required)</title>
+                <title>Enable event-based indexation for catalog entities (Restart required)</title>
                 <description>Any changes to the catalog entity will trigger a background task that will apply these changes in the search index.</description>
             </setting>
         </group>

--- a/VirtoCommerce.CatalogModule.Web/module.manifest
+++ b/VirtoCommerce.CatalogModule.Web/module.manifest
@@ -115,6 +115,13 @@
                 <title>Store serialized catalog objects in the index</title>
                 <description>Store serialized catalog objects in the index and return them in search results</description>
             </setting>
+            <setting>
+                <name>Catalog.Search.EventBasedIndexation.Enable</name>
+                <valueType>boolean</valueType>
+                <defaultValue>false</defaultValue>
+                <title>Set to True to enable event-based indexation for catalog entities (Restart required)</title>
+                <description>Any changes to the catalog entity will trigger a background task that will apply these changes in the search index.</description>
+            </setting>
         </group>
     </settings>
 


### PR DESCRIPTION
Add the new setting Catalog.Search.EventBasedIndexation.Enable  that will allows to  switch on/off  the event-based indexation behavior
https://github.com/VirtoCommerce/vc-module-catalog/issues/288