### PR TITLE
Added checking for null before working with property values

### DIFF
--- a/VirtoCommerce.CatalogModule.Data/Model/ItemEntity.cs
+++ b/VirtoCommerce.CatalogModule.Data/Model/ItemEntity.cs
@@ -260,7 +260,10 @@ namespace VirtoCommerce.CatalogModule.Data.Model
             CategoryId = string.IsNullOrEmpty(product.CategoryId) ? null : product.CategoryId;
 
             #region ItemPropertyValues
-            ItemPropertyValues = new ObservableCollection<PropertyValueEntity>(new ObservableCollection<PropertyValueEntity>(AbstractTypeFactory<PropertyValueEntity>.TryCreateInstance().FromModels(product.PropertyValues, pkMap)));
+            if (product.PropertyValues != null)
+            {
+                ItemPropertyValues = new ObservableCollection<PropertyValueEntity>(new ObservableCollection<PropertyValueEntity>(AbstractTypeFactory<PropertyValueEntity>.TryCreateInstance().FromModels(product.PropertyValues, pkMap)));
+            }
             #endregion
 
             #region Assets


### PR DESCRIPTION
Issue comes when we try to create item in the IItemService.Create() with object which have PropertyValues = null.
Dear colleagues, could you please tell me, why we do not initializing collections in the constructors?