### PR TITLE
fix: propertydictionaryitem api response type

### DIFF
--- a/VirtoCommerce.CatalogModule.Web.Core/Model/PropertyDictionaryItemSearchResult.cs
+++ b/VirtoCommerce.CatalogModule.Web.Core/Model/PropertyDictionaryItemSearchResult.cs
@@ -4,18 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using VirtoCommerce.Domain.Catalog.Model;
+using VirtoCommerce.Domain.Commerce.Model.Search;
 
 namespace VirtoCommerce.CatalogModule.Web.Model
 {
-	public class PropertyDictionaryItemSearchResult
+	public class PropertyDictionaryItemSearchResult: GenericSearchResult<PropertyDictionaryItem>
     {
-        public PropertyDictionaryItemSearchResult()
-        {
-            PropertyDictionaryItems = new List<PropertyDictionaryItem>();
-        }
-
-		public int TotalCount { get; set; }
-
-		public ICollection<PropertyDictionaryItem> PropertyDictionaryItems { get; set; }
     }
 }

--- a/VirtoCommerce.CatalogModule.Web.Core/Model/PropertyDictionaryItemSearchResult.cs
+++ b/VirtoCommerce.CatalogModule.Web.Core/Model/PropertyDictionaryItemSearchResult.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VirtoCommerce.Domain.Catalog.Model;
+
+namespace VirtoCommerce.CatalogModule.Web.Model
+{
+	public class PropertyDictionaryItemSearchResult
+    {
+        public PropertyDictionaryItemSearchResult()
+        {
+            PropertyDictionaryItems = new List<PropertyDictionaryItem>();
+        }
+
+		public int TotalCount { get; set; }
+
+		public ICollection<PropertyDictionaryItem> PropertyDictionaryItems { get; set; }
+    }
+}

--- a/VirtoCommerce.CatalogModule.Web.Core/Model/PropertyDictionaryItemSearchResult.cs
+++ b/VirtoCommerce.CatalogModule.Web.Core/Model/PropertyDictionaryItemSearchResult.cs
@@ -8,7 +8,7 @@ using VirtoCommerce.Domain.Commerce.Model.Search;
 
 namespace VirtoCommerce.CatalogModule.Web.Model
 {
-	public class PropertyDictionaryItemSearchResult: GenericSearchResult<PropertyDictionaryItem>
+    public class PropertyDictionaryItemSearchResult : GenericSearchResult<PropertyDictionaryItem>
     {
     }
 }

--- a/VirtoCommerce.CatalogModule.Web.Core/VirtoCommerce.CatalogModule.Web.Core.csproj
+++ b/VirtoCommerce.CatalogModule.Web.Core/VirtoCommerce.CatalogModule.Web.Core.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Model\MoveInfo.cs" />
     <Compile Include="Model\Product.cs" />
     <Compile Include="Model\ProductAssociation.cs" />
+    <Compile Include="Model\PropertyDictionaryItemSearchResult.cs" />
     <Compile Include="Model\PropertyValidationRule.cs" />
     <Compile Include="Model\PropertyValue.cs" />
     <Compile Include="Model\ResponseGroup.cs" />

--- a/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModulePropertyDictionaryItemsController.cs
+++ b/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModulePropertyDictionaryItemsController.cs
@@ -8,6 +8,7 @@ using VirtoCommerce.Domain.Catalog.Services;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Web.Security;
 using moduleModel = VirtoCommerce.Domain.Catalog.Model;
+using webModel = VirtoCommerce.CatalogModule.Web.Model;
 
 namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
 {
@@ -32,12 +33,17 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
         /// <returns></returns>
         [HttpPost]
         [Route("search")]
-        [ResponseType(typeof(moduleModel.PropertyDictionaryItem[]))]
+        [ResponseType(typeof(webModel.PropertyDictionaryItemSearchResult))]
         [CheckPermission(Permission = CatalogPredefinedPermissions.Read)]
         public IHttpActionResult SearchPropertyDictionaryItems(PropertyDictionaryItemSearchCriteria criteria)
         {
             var result = _propertyDictionarySearchService.Search(criteria);
-            return Ok(result);
+            var retVal = new webModel.PropertyDictionaryItemSearchResult
+            {
+                PropertyDictionaryItems = result.Results,
+                TotalCount = result.TotalCount
+            };
+            return Ok(retVal);
         }
 
         /// <summary>

--- a/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModulePropertyDictionaryItemsController.cs
+++ b/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModulePropertyDictionaryItemsController.cs
@@ -40,7 +40,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
             var result = _propertyDictionarySearchService.Search(criteria);
             var retVal = new webModel.PropertyDictionaryItemSearchResult
             {
-                PropertyDictionaryItems = result.Results,
+                Results = result.Results,
                 TotalCount = result.TotalCount
             };
             return Ok(retVal);


### PR DESCRIPTION
The PropertyDictionaryItem search api response type is 'PropertyDictionaryItem[]' not 'PropertyDictionaryItemSearchResult', it causes that autorest client api deserialize json failed.