### PR TITLE
VP-3296: Empty response when admin set several categories for products to display in association

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/DynamicAssociationSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/DynamicAssociationSearchRequestBuilder.cs
@@ -57,10 +57,15 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
         {
             if (!categoryIds.IsNullOrEmpty())
             {
-                ((AndFilter)_searchRequest.Filter).ChildFilters.Add(new WildCardTermFilter
+                ((AndFilter)_searchRequest.Filter).ChildFilters.Add(new OrFilter
                 {
-                    FieldName = "__outline",
-                    Value = string.Join(',', categoryIds.Select(x => $"*{x}")),
+                    ChildFilters = categoryIds
+                        .Select(x => new WildCardTermFilter
+                        {
+                            FieldName = "__outline",
+                            Value = $"*{x}"
+                        })
+                        .ToArray<IFilter>(),
                 });
             }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15198683/85326395-84f27900-b4cd-11ea-9387-8ad89b3e85e4.png)

![multiple_categories_search](https://user-images.githubusercontent.com/15198683/85326600-dac72100-b4cd-11ea-90da-726448c4b70b.gif)

Possible we should use OR filter on multiple values of each particular property.