### PR TITLE
VP-3246: Add ability to save inherited review as new for variations.

### DIFF
--- a/VirtoCommerce.CatalogModule.Web/Scripts/blades/editorialReview-detail.js
+++ b/VirtoCommerce.CatalogModule.Web/Scripts/blades/editorialReview-detail.js
@@ -95,17 +95,17 @@ angular.module('virtoCommerce.catalogModule')
         ];
 
         function saveChanges() {
-            var existReview = _.find(blade.item.reviews, function (x) { return x === blade.origEntity; });
+            blade.currentEntity.isInherited = false;
+            var existReview = _.find(blade.item.reviews, x => x === blade.origEntity);
             if (!existReview) {
                 blade.item.reviews.push(blade.origEntity);
-            };
-
+            } 
             angular.copy(blade.currentEntity, blade.origEntity);
         }
 
         function isDirty() {
             return !angular.equals(blade.currentEntity, blade.origEntity);
-        };
+        }
 
         function canSave() {
             return isDirty() && formScope && formScope.$valid;


### PR DESCRIPTION
### Problem
When I update variation descriptions, they are not saved

### Solution
Add ability to save inherited review as new for variations.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
