### PR TITLE
VP-3596: Fix cache clear after delete product association

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Services/AssociationService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/AssociationService.cs
@@ -125,7 +125,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
         {
             using (var repository = _repositoryFactory())
             {
-                var associations = repository.Associations.Where(x => ids.Contains(x.Id));
+                var associations = repository.Associations.Where(x => ids.Contains(x.Id)).ToArray();
 
                 foreach (var association in associations)
                 {


### PR DESCRIPTION
### Problem
Product association isn't removed in Admin after Delete from API

### Solution
Fix cache clear after delete product association

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
