### PR TITLE
VP-2519: Allow import SEO properties for item variations

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Model/SeoInfoEntity.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Model/SeoInfoEntity.cs
@@ -82,7 +82,9 @@ namespace VirtoCommerce.CatalogModule.Data.Model
             MetaDescription = seoInfo.MetaDescription;
             MetaKeywords = seoInfo.MetaKeywords;
             StoreId = seoInfo.StoreId;
-
+            CategoryId = seoInfo.ObjectType == "Category" ? seoInfo.ObjectId : null;
+            ItemId = seoInfo.ObjectType == "CatalogProduct" ? seoInfo.ObjectId : null;
+            
             return this;
         }
 


### PR DESCRIPTION
### Problem
SeoInfo can't  be imported for variations

### Solution
add fields to mapping method

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
