### PR TITLE
VP-2052: Catalog - Export - Error export empty catalog

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/categories-items-list.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/categories-items-list.js
@@ -425,7 +425,7 @@ angular.module('virtoCommerce.catalogModule')
                         };
                         bladeNavigationService.showBlade(newBlade, blade);
                     },
-                    canExecuteMethod: function () { return blade.catalogId; },
+                    canExecuteMethod: function () { return $scope.items.length && blade.catalogId; },
                     permission: 'catalog:export'
                 },
                 {


### PR DESCRIPTION
### Problem
There are errors when we click to export button on blade with empty categories list

### Solution
Disable export button when category is empty

### Proposed of changes
Disable export button when category is empty

### Additional context (optional)
![export](https://user-images.githubusercontent.com/15198683/90859630-da8db980-e388-11ea-8602-990c72ca7985.gif)

### Make sure these boxes are checked:
- [ ] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [ ] Check methods and variable namings - it should be self descriptive, no typos
- [ ] Check you did not introduce breaking changes in API and public models/services.
- [ ] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [ ] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [ ] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [ ] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [ ] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [ ] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
