### PR TITLE
VP-3515: Settings -> Catalog -> Add correct name and description to option

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/ModuleConstants.cs
@@ -23,7 +23,7 @@ namespace VirtoCommerce.CatalogModule.Core
                   CategoryChange = "bulk-action:category:change",
                   PropertiesUpdate = "bulk-action:properties:update";
 
-                public static string[] AllPermissions { get; } = new[] { Access, Create, Read, Update, Delete, Export, Import, CatalogBrowseFiltersRead, CatalogBrowseFiltersUpdate, CategoryChange, PropertiesUpdate };
+                public static string[] AllPermissions { get; } = { Access, Create, Read, Update, Delete, Export, Import, CatalogBrowseFiltersRead, CatalogBrowseFiltersUpdate, CategoryChange, PropertiesUpdate };
             }
         }
 
@@ -45,7 +45,7 @@ namespace VirtoCommerce.CatalogModule.Core
                     ValueType = SettingValueType.ShortText,
                     GroupName = "Catalog|General",
                     IsDictionary = true,
-                    AllowedValues = new string[] { "Accessories", "Related Items" }
+                    AllowedValues = new [] { "Accessories", "Related Items" }
                 };
 
                 public static SettingDescriptor EditorialReviewTypes { get; } = new SettingDescriptor
@@ -55,20 +55,12 @@ namespace VirtoCommerce.CatalogModule.Core
                     GroupName = "Catalog|General",
                     IsDictionary = true,
                     DefaultValue = "QuickReview",
-                    AllowedValues = new string[] { "QuickReview", "FullReview" }
+                    AllowedValues = new [] { "QuickReview", "FullReview" }
                 };
 
                 public static SettingDescriptor CodesInOutline { get; } = new SettingDescriptor
                 {
                     Name = "Catalog.CodesInOutline",
-                    GroupName = "Catalog|General",
-                    ValueType = SettingValueType.Boolean,
-                    DefaultValue = false
-                };
-
-                public static SettingDescriptor ExposeAliasInDictionary { get; } = new SettingDescriptor
-                {
-                    Name = "Catalog.ExposeAliasInDictionary",
                     GroupName = "Catalog|General",
                     ValueType = SettingValueType.Boolean,
                     DefaultValue = false
@@ -101,7 +93,6 @@ namespace VirtoCommerce.CatalogModule.Core
                                    EditorialReviewTypes,
                                    CodesInOutline,
                                    EventBasedIndexation,
-                                   ExposeAliasInDictionary, // remove this redundant setting after sample data is fixed
                                    UseSeoDeduplication
                                };
                     }


### PR DESCRIPTION
### Problem
Setting Catalog.ExposeAliasInDictionary useless and should be removed

### Solution
Remove setting

### Proposed of changes
Remove setting

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
