### PR TITLE
VP-5764: Fix aggregation properties search

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogBrowseFiltersController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogBrowseFiltersController.cs
@@ -29,7 +29,6 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
 
         private readonly IStoreService _storeService;
         private readonly IPropertyService _propertyService;
-        private readonly IPropertySearchService _propertySearchService;
         private readonly IBrowseFilterService _browseFilterService;
         private readonly IPropertyDictionaryItemSearchService _propDictItemsSearchService;
 
@@ -37,14 +36,12 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
             IStoreService storeService
             , IPropertyService propertyService
             , IBrowseFilterService browseFilterService
-            , IPropertyDictionaryItemSearchService propDictItemsSearchService
-            , IPropertySearchService propertySearchService)
+            , IPropertyDictionaryItemSearchService propDictItemsSearchService)
         {
             _storeService = storeService;
             _propertyService = propertyService;
             _browseFilterService = browseFilterService;
             _propDictItemsSearchService = propDictItemsSearchService;
-            _propertySearchService = propertySearchService;
         }
 
         /// <summary>
@@ -88,7 +85,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
         [Route("{storeId}/properties")]
         [Authorize(ModuleConstants.Security.Permissions.CatalogBrowseFiltersUpdate)]
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
-        public async Task<ActionResult> SetAggregationProperties(string storeId, [FromBody]AggregationProperty[] browseFilterProperties)
+        public async Task<ActionResult> SetAggregationProperties(string storeId, [FromBody] AggregationProperty[] browseFilterProperties)
         {
             var store = await _storeService.GetByIdAsync(storeId, StoreResponseGroup.StoreInfo.ToString());
             if (store == null)
@@ -117,8 +114,8 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
             var store = await _storeService.GetByIdAsync(storeId, StoreResponseGroup.StoreInfo.ToString());
             if (store != null)
             {
-                var catalogPropertiesSearchResult = await _propertySearchService.SearchPropertiesAsync(new PropertySearchCriteria { PropertyNames = new[] { propertyName }, CatalogId = store.Catalog, Take = 1 });
-                var property = catalogPropertiesSearchResult.Results.FirstOrDefault(p => p.Name.EqualsInvariant(propertyName) && p.Dictionary);
+                var catalogProperties = await _propertyService.GetAllCatalogPropertiesAsync(store.Catalog);
+                var property = catalogProperties.FirstOrDefault(p => p.Name.EqualsInvariant(propertyName) && p.Dictionary);
                 if (property != null)
                 {
                     var searchResult = await _propDictItemsSearchService.SearchAsync(new PropertyDictionaryItemSearchCriteria { PropertyIds = new[] { property.Id }, Take = int.MaxValue });
@@ -131,7 +128,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
 
         private async Task<IList<AggregationProperty>> GetAllPropertiesAsync(string catalogId, IEnumerable<string> currencies)
         {
-            var result = (await _propertySearchService.SearchPropertiesAsync(new PropertySearchCriteria { CatalogId = catalogId, Take = int.MaxValue })).Results
+            var result = (await _propertyService.GetAllCatalogPropertiesAsync(catalogId))
                             .Select(p => new AggregationProperty { Type = _attributeType, Name = p.Name })
                             .ToList();
 


### PR DESCRIPTION
Use `IPropertyService.GetAllCatalogPropertiesAsync` for properties search instead of `IPropertySearchService`, because `GetAllCatalogPropertiesAsync` could get properties from linked categories