### PR TITLE
VP-5502 User see only products and variations properties

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/Model/Property.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/Property.cs
@@ -55,6 +55,7 @@ namespace VirtoCommerce.CatalogModule.Core.Model
         public PropertyValueType ValueType { get; set; }
         public PropertyType Type { get; set; }
         public string OuterId { get; set; }
+        public string OwnerName { get; set; }
 
 
         public IList<PropertyValue> Values { get; set; } = new List<PropertyValue>();

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/action-edit-properties.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/action-edit-properties.js
@@ -42,7 +42,12 @@ angular.module('virtoCommerce.catalogModule')
                                 prop.UseDefaultUIForEdit = true;
                             }
                             prop.values = [];
-                            prop.group = 'All properties';
+                            if (prop.ownerName === 'Native properties') {
+                                prop.group = 'Native product properties';
+                            } else {
+                                prop.group = 'Extended properties';
+                            }
+                            
                         });
                     blade.isLoading = false;
                 });

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/step-select-properties.tpl.html
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/step-select-properties.tpl.html
@@ -11,7 +11,7 @@
                     <a class="btn-ico fa fa-times-circle" ng-click="clearAllInGroup(key)"></a>
                     <ui-select multiple ng-model="blade.selectedEntities[key]" on-select="sortSelected(key)">
                         <ui-select-match placeholder="{{'export.blades.export-settings.labels.exported-properties-group' | translate}}">{{$item.name}}</ui-select-match>
-                        <ui-select-choices group-by="'path'" repeat="x as x in values | orderBy: 'name' | filter: { name: $select.search }">
+                        <ui-select-choices group-by="'ownerName'" repeat="x as x in values | orderBy: 'name' | filter: { name: $select.search }">
                             <span ng-bind-html="x.name | highlight: $select.search"></span>
                         </ui-select-choices>
                     </ui-select>

--- a/tests/VirtoCommerce.CatalogModule.Tests/BulkPropertyUpdateManagerTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/BulkPropertyUpdateManagerTests.cs
@@ -81,22 +81,27 @@ namespace VirtoCommerce.CatalogModule.Tests
         {
             var dataSourceFactory = new Mock<IDataSourceFactory>();
             var itemService = new Mock<IItemService>();
-            var manager = new BulkPropertyUpdateManager(dataSourceFactory.Object, itemService.Object);
+            var categoryService = new Mock<ICategoryService>();
+            var catalogService = new Mock<ICatalogService>();
+            var manager = new BulkPropertyUpdateManager(dataSourceFactory.Object, itemService.Object, categoryService.Object, catalogService.Object);
             return manager;
         }
 
         private IBulkPropertyUpdateManager BuildManager(IMock<IDataSourceFactory> dataSourceFactory)
         {
             var itemService = new Mock<IItemService>();
-            var manager = new BulkPropertyUpdateManager(dataSourceFactory.Object, itemService.Object);
+            var categoryService = new Mock<ICategoryService>();
+            var catalogService = new Mock<ICatalogService>();
+
+            var manager = new BulkPropertyUpdateManager(dataSourceFactory.Object, itemService.Object, categoryService.Object, catalogService.Object);
             return manager;
         }
 
-        private IBulkPropertyUpdateManager BuildManager(
-            IMock<IDataSourceFactory> dataSourceFactory,
-            IMock<IItemService> itemService)
+        private IBulkPropertyUpdateManager BuildManager(IMock<IDataSourceFactory> dataSourceFactory, IMock<IItemService> itemService)
         {
-            var manager = new BulkPropertyUpdateManager(dataSourceFactory.Object, itemService.Object);
+            var categoryService = new Mock<ICategoryService>();
+            var catalogService = new Mock<ICatalogService>();
+            var manager = new BulkPropertyUpdateManager(dataSourceFactory.Object, itemService.Object, categoryService.Object, catalogService.Object);
             return manager;
         }
     }


### PR DESCRIPTION
### Problem
VP-5502 User see only products and variations properties

### Solution
A clear and concise description of what you want to happen.

### Proposed of changes
Describe the technical details of realization provided by you.

### Additional context (optional)
Add any other context or screenshots about the feature request here.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
