### PR TITLE
VP-3570: Error when user select LongText-dictionary-multivalue-multilang as property for dynamic association

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.tpl.html
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/directives/property2.tpl.html
@@ -248,19 +248,19 @@
     </script>
     <script type="text/ng-template" id="LongText-multivalue-multilang.html">
         <div class="form-group" ng-repeat="(language, langValuesGroup) in context.langValuesMap" ng-if="isLanguageVisible(language)">
-            <div class="vc-catalog form-input __langs" ng-repeat="val in langValuesGroup.currentPropValues track by $index">                                
-                    <label class="lang-code">{{language}}</label>
-                    <textarea ng-disabled="currentEntity.isReadOnly"
-                              ng-required="currentEntity.required && !currentEntity.isReadOnly"
-                              ng-model="val.value"
-                              name="{{currentEntity.name}}"
-                              ng-maxlength="currentEntity.validationRule.charCountMax"
-                              ng-minlength="currentEntity.validationRule.charCountMin"
-                              ng-pattern="currentEntity.validationRule.regExp" />
-                    <va-property-messages></va-property-messages>
-                    <a ng-if="!currentEntity.isReadOnly" ng-click="langValuesGroup.currentPropValues.splice(langValuesGroup.currentPropValues.indexOf(val),1)">remove</a>                
+            <div class="vc-catalog form-input __langs" ng-repeat="val in langValuesGroup.currentPropValues track by $index">
+                <label class="lang-code">{{language}}</label>
+                <textarea ng-disabled="currentEntity.isReadOnly"
+                          ng-required="currentEntity.required && !currentEntity.isReadOnly"
+                          ng-model="val.value"
+                          name="{{currentEntity.name}}"
+                          ng-maxlength="currentEntity.validationRule.charCountMax"
+                          ng-minlength="currentEntity.validationRule.charCountMin"
+                          ng-pattern="currentEntity.validationRule.regExp" />
+                <va-property-messages></va-property-messages>
+                <a ng-if="!currentEntity.isReadOnly" ng-click="langValuesGroup.currentPropValues.splice(langValuesGroup.currentPropValues.indexOf(val),1)">remove</a>
                 <a ng-if="!currentEntity.isReadOnly" ng-click="langValuesGroup.currentPropValues.push({value:'', languageCode:language})" style="cursor:pointer;">add value</a>
-            </div>            
+            </div>
         </div>
     </script>
     <script type="text/ng-template" id="Number-multivalue-multilang.html">
@@ -294,6 +294,17 @@
         <div class="form-input">
             <ui-select ng-model="context.currentPropValues[0]" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
                 <ui-select-match allow-clear="true" placeholder="{{ 'platform.genericValueInput.placeholders.number' | translate }}">{{$select.selected.value}}</ui-select-match>
+                <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
+                    <span ng-bind-html="propValue.value | highlight: $select.search"></span>
+                </ui-select-choices>
+            </ui-select>
+        </div>
+    </script>
+
+    <script type="text/ng-template" id="LongText-dictionary-multivalue-multilang.html">
+        <div class="form-input">
+            <ui-select multiple ng-model="context.currentPropValues" ng-disabled="currentEntity.isReadOnly" ng-required="currentEntity.required">
+                <ui-select-match placeholder="{{ 'platform.genericValueInput.placeholders.long-text-dictionary-multivalue-multilang' | translate }}">{{$item.value}}</ui-select-match>
                 <ui-select-choices repeat="propValue in context.allDictionaryValues | filter: {value: $select.search} | orderBy: 'value'" refresh="loadDictionaryValues($select)" refresh-delay="200" when-scrolled="loadNextDictionaryValues($select)">
                     <span ng-bind-html="propValue.value | highlight: $select.search"></span>
                 </ui-select-choices>


### PR DESCRIPTION
### Problem
Error when user select LongText-dictionary-multivalue-multilang as property for dynamic association

### Solution
Add template LongText-dictionary-multivalue-multilang.html

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
