### PR TITLE
VP-6015: Fix category associations search

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Repositories/CatalogRepositoryImpl.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Repositories/CatalogRepositoryImpl.cs
@@ -565,7 +565,7 @@ namespace VirtoCommerce.CatalogModule.Data.Repositories
                     Item_CTE AS
                     (
                         SELECT
-                            a.Id
+                            CONVERT(nvarchar(64), newid()) as Id
                             ,a.AssociationType
                             ,a.Priority
                             ,a.ItemId


### PR DESCRIPTION
By inheriting `AssociationEntity` from `Entity` in https://github.com/VirtoCommerce/vc-module-catalog/commit/2a0249ada6c96bec8030ac0147fc885c6c38166e#diff-2d38b26f0e0caee3d2b827a89deadf10dad1ffb852baeb8627b3c75eb56e14c0R9, the result of `CatalogRepositoryImpl.SearchAssociations` was changed - because `Entity.Equals` differs from previous `ValueObject.Equals` based on equality components. `Entity.Equals` uses `Id`, which is the same in query for all items of associated category. Seems while materializing results, EF uses `Equals`, which leads to equality of all association elements in one associated category.
Fixed this problem by generating new Id for every association element inside every associated category.