### PR TITLE
VP-5986: Copy link does not work

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/item-asset-list.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/item-asset-list.js
@@ -96,7 +96,7 @@ angular.module('virtoCommerce.catalogModule')
         };
 
         $scope.copyUrl = function (data) {
-            $translate('catalog.blades.item-asset-detail.labels.copy-url-prompt').then(function (promptMessage) {
+            $translate('catalog.blades.item-asset-list.labels.copy-url-prompt').then(function (promptMessage) {
                 window.prompt(promptMessage, data.url);
             });
         }


### PR DESCRIPTION
## Related task: 
VP-5986 [QA Regression v3] Option"Copy link" not working in products's assets widget

## Changes:
Fix localization label