### PR TITLE
Add excluded properties to category

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/Extensions/PropertyExtensions.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Extensions/PropertyExtensions.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.CatalogModule.Core.Extensions
+{
+    public static class PropertyExtensions
+    {
+        public static bool HasPropertyExcluded(this IHasExcludedProperties obj, string propertyName)
+        {
+            return obj.ExcludedProperties?.Any(x => x.Name.EqualsInvariant(propertyName)) == true;
+        }
+
+        public static void InheritExcludedProperties<T>(this T obj, IHasExcludedProperties parent)
+            where T : IHasProperties, IHasExcludedProperties
+        {
+            if (parent == null)
+            {
+                return;
+            }
+
+            if (parent.ExcludedProperties?.Any() == true)
+            {
+                // Add the excluded properties as inherited excluded properties
+                var inheritedExcludedProperties = parent.ExcludedProperties.Select(x => x.Inherit()).ToArray();
+                obj.ExcludedProperties ??= new List<ExcludedProperty>();
+                obj.ExcludedProperties.AddDistinct(inheritedExcludedProperties);
+            }
+
+            if (obj.Properties != null && obj.ExcludedProperties?.Any() == true)
+            {
+                var propertiesToRemove = obj.Properties.Where(x => obj.HasPropertyExcluded(x.Name)).ToArray();
+                foreach (var propertyToRemove in propertiesToRemove)
+                {
+                    obj.Properties.Remove(propertyToRemove);
+                }
+            }
+        }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Core/Extensions/PropertyExtensions.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Extensions/PropertyExtensions.cs
@@ -30,11 +30,7 @@ namespace VirtoCommerce.CatalogModule.Core.Extensions
 
             if (obj.Properties != null && obj.ExcludedProperties?.Any() == true)
             {
-                var propertiesToRemove = obj.Properties.Where(x => obj.HasPropertyExcluded(x.Name)).ToArray();
-                foreach (var propertyToRemove in propertiesToRemove)
-                {
-                    obj.Properties.Remove(propertyToRemove);
-                }
+                obj.Properties = obj.Properties.Where(x => !obj.HasPropertyExcluded(x.Name)).ToList();
             }
         }
     }

--- a/src/VirtoCommerce.CatalogModule.Core/Model/Category.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/Category.cs
@@ -58,6 +58,7 @@ namespace VirtoCommerce.CatalogModule.Core.Model
 
         public bool? IsActive { get; set; }
         public string OuterId { get; set; }
+        public string[] ExcludedProperties { get; set; }
         [JsonIgnore]
         public IList<Category> Children { get; set; }
 

--- a/src/VirtoCommerce.CatalogModule.Core/Model/Category.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/Category.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
+using VirtoCommerce.CatalogModule.Core.Extensions;
 using VirtoCommerce.CoreModule.Core.Outlines;
 using VirtoCommerce.CoreModule.Core.Seo;
 using VirtoCommerce.ExportModule.Core.Model;
@@ -66,7 +67,7 @@ namespace VirtoCommerce.CatalogModule.Core.Model
         #endregion
 
         #region IHasExcludedProperties members
-        public IList<string> ExcludedProperties { get; set; }
+        public IList<ExcludedProperty> ExcludedProperties { get; set; }
         #endregion
 
         #region ILinkSupport members
@@ -113,22 +114,14 @@ namespace VirtoCommerce.CatalogModule.Core.Model
 
         public virtual void TryInheritFrom(IEntity parent)
         {
-            if (ExcludedProperties == null)
-            {
-                ExcludedProperties = new List<string>();
-            }
-            if (parent is IHasExcludedProperties hasExcludeProperties &&
-                hasExcludeProperties.ExcludedProperties?.Any() == true)
-            {
-                ExcludedProperties.AddRange(hasExcludeProperties.ExcludedProperties);
-            }
+            this.InheritExcludedProperties(parent as IHasExcludedProperties);
 
             if (parent is IHasProperties hasProperties)
             {
                 //Properties inheritance
                 foreach (var parentProperty in hasProperties.Properties ?? Array.Empty<Property>())
                 {
-                    if (ExcludedProperties.Contains(parentProperty.Name, StringComparer.OrdinalIgnoreCase))
+                    if (this.HasPropertyExcluded(parentProperty.Name))
                     {
                         continue;
                     }

--- a/src/VirtoCommerce.CatalogModule.Core/Model/ExcludedProperty.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/ExcludedProperty.cs
@@ -1,0 +1,41 @@
+using System;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.CatalogModule.Core.Model
+{
+    public class ExcludedProperty
+    {
+        public string Name { get; set; }
+
+        public bool IsInherited { get; set; }
+
+        public ExcludedProperty()
+        {
+        }
+
+        public ExcludedProperty(string name)
+        {
+            Name = name;
+        }
+
+        public ExcludedProperty Inherit()
+        {
+            return IsInherited ? this : new ExcludedProperty(Name) { IsInherited = true };
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ExcludedProperty excludedProperty)
+            {
+                return Name.EqualsInvariant(excludedProperty.Name);
+            }
+
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Name.GetHashCode();
+        }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Core/Model/ExcludedProperty.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/ExcludedProperty.cs
@@ -1,9 +1,9 @@
-using System;
+using System.Collections.Generic;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.CatalogModule.Core.Model
 {
-    public class ExcludedProperty
+    public class ExcludedProperty : ValueObject
     {
         public string Name { get; set; }
 
@@ -23,19 +23,9 @@ namespace VirtoCommerce.CatalogModule.Core.Model
             return IsInherited ? this : new ExcludedProperty(Name) { IsInherited = true };
         }
 
-        public override bool Equals(object obj)
+        protected override IEnumerable<object> GetEqualityComponents()
         {
-            if (obj is ExcludedProperty excludedProperty)
-            {
-                return Name.EqualsInvariant(excludedProperty.Name);
-            }
-
-            return base.Equals(obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return Name.GetHashCode();
+            yield return Name;
         }
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Core/Model/IHasExcludedProperties.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/IHasExcludedProperties.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace VirtoCommerce.CatalogModule.Core.Model
+{
+    public interface IHasExcludedProperties
+    {
+        IList<string> ExcludedProperties { get; }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Core/Model/IHasExcludedProperties.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/IHasExcludedProperties.cs
@@ -4,6 +4,6 @@ namespace VirtoCommerce.CatalogModule.Core.Model
 {
     public interface IHasExcludedProperties
     {
-        IList<string> ExcludedProperties { get; }
+        IList<ExcludedProperty> ExcludedProperties { get; set; }
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Core/Model/Property.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/Property.cs
@@ -84,6 +84,15 @@ namespace VirtoCommerce.CatalogModule.Core.Model
             return string.Equals(Name, propValue.PropertyName, StringComparison.InvariantCultureIgnoreCase) && ValueType == propValue.ValueType;
         }
 
+        public override bool Equals(object obj)
+        {
+            if (obj is Property prop)
+            {
+                return IsSame(prop);
+            }
+            return base.Equals(obj);
+        }
+
         #region IInheritable Members
         public virtual bool IsInherited { get; set; }
 

--- a/src/VirtoCommerce.CatalogModule.Core/Model/Property.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/Property.cs
@@ -12,10 +12,10 @@ namespace VirtoCommerce.CatalogModule.Core.Model
     {
         /// <summary>
         /// Gets or sets a value indicating whether user can change property value.
-        /// </summary>     
+        /// </summary>
         public bool IsReadOnly { get; set; }
         /// <summary>
-        /// Gets or sets a value indicating whether user can change property metadata or remove this property. 
+        /// Gets or sets a value indicating whether user can change property metadata or remove this property.
         /// </summary>
         public bool IsManageable => !IsTransient();
         /// <summary>
@@ -82,15 +82,6 @@ namespace VirtoCommerce.CatalogModule.Core.Model
         public virtual bool IsSuitableForValue(PropertyValue propValue)
         {
             return string.Equals(Name, propValue.PropertyName, StringComparison.InvariantCultureIgnoreCase) && ValueType == propValue.ValueType;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is Property prop)
-            {
-                return IsSame(prop);
-            }
-            return base.Equals(obj);
         }
 
         #region IInheritable Members

--- a/src/VirtoCommerce.CatalogModule.Data/Migrations/20201123103844_AddCategoryExcludedProperties.Designer.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Migrations/20201123103844_AddCategoryExcludedProperties.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.CatalogModule.Data.Repositories;
 
 namespace VirtoCommerce.CatalogModule.Data.Migrations
 {
     [DbContext(typeof(CatalogDbContext))]
-    partial class CatalogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201123103844_AddCategoryExcludedProperties")]
+    partial class AddCategoryExcludedProperties
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.CatalogModule.Data/Migrations/20201123103844_AddCategoryExcludedProperties.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Migrations/20201123103844_AddCategoryExcludedProperties.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace VirtoCommerce.CatalogModule.Data.Migrations
+{
+    public partial class AddCategoryExcludedProperties : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExcludedProperties",
+                table: "Category",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExcludedProperties",
+                table: "Category");
+        }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Data/Model/CategoryEntity.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Model/CategoryEntity.cs
@@ -70,7 +70,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
             = new NullCollection<PropertyValueEntity>();
 
         /// <summary>
-        /// It new navigation property for link replace to stupid CategoryLink (will be removed later) 
+        /// It new navigation property for link replace to stupid CategoryLink (will be removed later)
         /// </summary>
         public virtual ObservableCollection<CategoryRelationEntity> OutgoingLinks { get; set; }
             = new NullCollection<CategoryRelationEntity>();
@@ -111,7 +111,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
 
             category.ParentId = ParentCategoryId;
             category.IsActive = IsActive;
-            category.ExcludedProperties = ExcludedProperties;
+            category.ExcludedProperties = ExcludedProperties?.Select(x => new ExcludedProperty(x)).ToList();
 
             category.Links = OutgoingLinks.Select(x => x.ToModel(new CategoryLink())).ToList();
             category.Images = Images.OrderBy(x => x.SortOrder).Select(x => x.ToModel(AbstractTypeFactory<Image>.TryCreateInstance())).ToList();
@@ -188,7 +188,10 @@ namespace VirtoCommerce.CatalogModule.Data.Model
             EndDate = DateTime.UtcNow.AddYears(100);
             StartDate = DateTime.UtcNow;
             IsActive = category.IsActive ?? true;
-            ExcludedProperties = category.ExcludedProperties;
+            ExcludedProperties = category.ExcludedProperties?
+                .Where(x => !x.IsInherited)
+                .Select(x => x.Name)
+                .ToList();
 
             if (!category.Properties.IsNullOrEmpty())
             {
@@ -197,7 +200,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
                 {
                     if (property.Values != null)
                     {
-                        //Do not use values from inherited properties 
+                        //Do not use values from inherited properties
                         foreach (var propValue in property.Values)
                         {
                             if (propValue != null && !propValue.IsInherited)
@@ -209,7 +212,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
                             }
                             else
                             {
-                                //Add empty property value for null values to be able remove these values from db in the lines below 
+                                //Add empty property value for null values to be able remove these values from db in the lines below
                                 propValues.Add(new PropertyValue());
                             }
                         }

--- a/src/VirtoCommerce.CatalogModule.Data/Model/CategoryEntity.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Model/CategoryEntity.cs
@@ -84,7 +84,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
         public virtual ObservableCollection<SeoInfoEntity> SeoInfos { get; set; }
             = new NullCollection<SeoInfoEntity>();
 
-        public virtual string[] ExcludedProperties { get; set; }
+        public virtual IList<string> ExcludedProperties { get; set; }
 
         #endregion
 

--- a/src/VirtoCommerce.CatalogModule.Data/Model/CategoryEntity.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Model/CategoryEntity.cs
@@ -84,6 +84,8 @@ namespace VirtoCommerce.CatalogModule.Data.Model
         public virtual ObservableCollection<SeoInfoEntity> SeoInfos { get; set; }
             = new NullCollection<SeoInfoEntity>();
 
+        public virtual string[] ExcludedProperties { get; set; }
+
         #endregion
 
         public virtual Category ToModel(Category category)
@@ -109,6 +111,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
 
             category.ParentId = ParentCategoryId;
             category.IsActive = IsActive;
+            category.ExcludedProperties = ExcludedProperties;
 
             category.Links = OutgoingLinks.Select(x => x.ToModel(new CategoryLink())).ToList();
             category.Images = Images.OrderBy(x => x.SortOrder).Select(x => x.ToModel(AbstractTypeFactory<Image>.TryCreateInstance())).ToList();
@@ -185,6 +188,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
             EndDate = DateTime.UtcNow.AddYears(100);
             StartDate = DateTime.UtcNow;
             IsActive = category.IsActive ?? true;
+            ExcludedProperties = category.ExcludedProperties;
 
             if (!category.Properties.IsNullOrEmpty())
             {
@@ -248,6 +252,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
             target.TaxType = TaxType;
             target.Priority = Priority;
             target.IsActive = IsActive;
+            target.ExcludedProperties = ExcludedProperties;
 
             if (!CategoryPropertyValues.IsNullCollection())
             {

--- a/src/VirtoCommerce.CatalogModule.Data/Repositories/CatalogDbContext.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Repositories/CatalogDbContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using EntityFrameworkCore.Triggers;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
@@ -33,7 +34,7 @@ namespace VirtoCommerce.CatalogModule.Data.Repositories
                 .WithMany().HasForeignKey(x => x.CatalogId).IsRequired().OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<CategoryEntity>().Property(x => x.ExcludedProperties).HasConversion(
                 x => JsonConvert.SerializeObject(x),
-                x => JsonConvert.DeserializeObject<string[]>(x));
+                x => JsonConvert.DeserializeObject<List<string>>(x));
             #endregion
 
             #region Item

--- a/src/VirtoCommerce.CatalogModule.Data/Repositories/CatalogDbContext.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Repositories/CatalogDbContext.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using EntityFrameworkCore.Triggers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Internal;
 using Newtonsoft.Json;
 using VirtoCommerce.CatalogModule.Data.Model;
 
@@ -33,8 +34,8 @@ namespace VirtoCommerce.CatalogModule.Data.Repositories
             modelBuilder.Entity<CategoryEntity>().HasOne(x => x.Catalog)
                 .WithMany().HasForeignKey(x => x.CatalogId).IsRequired().OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<CategoryEntity>().Property(x => x.ExcludedProperties).HasConversion(
-                x => JsonConvert.SerializeObject(x),
-                x => JsonConvert.DeserializeObject<List<string>>(x));
+                x => x != null && x.Any() ? JsonConvert.SerializeObject(x) : null,
+                x => x != null ? JsonConvert.DeserializeObject<List<string>>(x) : null);
             #endregion
 
             #region Item
@@ -126,7 +127,7 @@ namespace VirtoCommerce.CatalogModule.Data.Repositories
             modelBuilder.Entity<EditorialReviewEntity>().Property(x => x.Id).HasMaxLength(128).ValueGeneratedOnAdd();
             modelBuilder.Entity<EditorialReviewEntity>().HasOne(x => x.CatalogItem).WithMany(x => x.EditorialReviews)
                 .HasForeignKey(x => x.ItemId).IsRequired().OnDelete(DeleteBehavior.Cascade);
-            #endregion         
+            #endregion
 
             #region Association
             modelBuilder.Entity<AssociationEntity>().ToTable("Association").HasKey(x => x.Id);

--- a/src/VirtoCommerce.CatalogModule.Data/Repositories/CatalogDbContext.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Repositories/CatalogDbContext.cs
@@ -1,5 +1,6 @@
 using EntityFrameworkCore.Triggers;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
 using VirtoCommerce.CatalogModule.Data.Model;
 
 namespace VirtoCommerce.CatalogModule.Data.Repositories
@@ -30,6 +31,9 @@ namespace VirtoCommerce.CatalogModule.Data.Repositories
                 .WithMany().HasForeignKey(x => x.ParentCategoryId).OnDelete(DeleteBehavior.Restrict);
             modelBuilder.Entity<CategoryEntity>().HasOne(x => x.Catalog)
                 .WithMany().HasForeignKey(x => x.CatalogId).IsRequired().OnDelete(DeleteBehavior.Cascade);
+            modelBuilder.Entity<CategoryEntity>().Property(x => x.ExcludedProperties).HasConversion(
+                x => JsonConvert.SerializeObject(x),
+                x => JsonConvert.DeserializeObject<string[]>(x));
             #endregion
 
             #region Item


### PR DESCRIPTION
Adds the ability to store excluded property names per category. The excluded properties are then ignored in the inheritance of a category and its products.