### PR TITLE
VP-6151:  search products does not work with outlines in search criteria

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/CatalogDocumentBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/CatalogDocumentBuilder.cs
@@ -79,7 +79,9 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
         {
             return outlines
                 .SelectMany(ExpandOutline)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
+                // VP-6151 Need to save outlines in index in lower case as we are converting search criteria outlines to lower case
+                .Select(x=>x.ToLowerInvariant())
+                .Distinct()
                 .ToArray();
         }
 

--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/CatalogDocumentBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/CatalogDocumentBuilder.cs
@@ -23,56 +23,56 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
         protected virtual void IndexCustomProperties(IndexDocument document, ICollection<Property> properties, ICollection<PropertyType> contentPropertyTypes)
         {
             foreach (var property in properties)
-                foreach (var propValue in property.Values?.Where(x => x.Value != null) ?? Array.Empty<PropertyValue>())
+            foreach (var propValue in property.Values?.Where(x => x.Value != null) ?? Array.Empty<PropertyValue>())
+            {
+                var propertyName = propValue.PropertyName?.ToLowerInvariant();
+                if (!string.IsNullOrEmpty(propertyName))
                 {
-                    var propertyName = propValue.PropertyName?.ToLowerInvariant();
-                    if (!string.IsNullOrEmpty(propertyName))
+                    var isCollection = property?.Multivalue == true;
+
+                    switch (propValue.ValueType)
                     {
-                        var isCollection = property?.Multivalue == true;
-
-                        switch (propValue.ValueType)
-                        {
-                            case PropertyValueType.Boolean:
-                            case PropertyValueType.DateTime:
-                            case PropertyValueType.Integer:
-                            case PropertyValueType.Number:
-                                document.Add(new IndexDocumentField(propertyName, propValue.Value) { IsRetrievable = true, IsFilterable = true, IsCollection = isCollection });
-                                break;
-                            case PropertyValueType.LongText:
-                                document.Add(new IndexDocumentField(propertyName, propValue.Value.ToString().ToLowerInvariant()) { IsRetrievable = true, IsSearchable = true, IsCollection = isCollection });
-                                break;
-                            case PropertyValueType.ShortText:
-                                // Index alias when it is available instead of display value.
-                                // Do not tokenize small values as they will be used for lookups and filters.
-                                var shortTextValue = propValue.Alias ?? propValue.Value.ToString();
-                                document.Add(new IndexDocumentField(propertyName, shortTextValue) { IsRetrievable = true, IsFilterable = true, IsCollection = isCollection });
-                                break;
-                            case PropertyValueType.GeoPoint:
-                                document.Add(new IndexDocumentField(propertyName, GeoPoint.TryParse((string)propValue.Value)) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
-                                break;
-                        }
-                    }
-
-                    // Add value to the searchable content field if property type is uknown or if it is present in the provided list
-                    if (property == null || contentPropertyTypes == null || contentPropertyTypes.Contains(property.Type))
-                    {
-                        var contentField = string.Concat("__content", property != null && property.Multilanguage && !string.IsNullOrWhiteSpace(propValue.LanguageCode) ? "_" + propValue.LanguageCode.ToLowerInvariant() : string.Empty);
-
-                        switch (propValue.ValueType)
-                        {
-                            case PropertyValueType.LongText:
-                            case PropertyValueType.ShortText:
-                                var stringValue = propValue.Value.ToString();
-
-                                if (!string.IsNullOrWhiteSpace(stringValue)) // don't index empty values
-                                {
-                                    document.Add(new IndexDocumentField(contentField, stringValue.ToLower()) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
-                                }
-
-                                break;
-                        }
+                        case PropertyValueType.Boolean:
+                        case PropertyValueType.DateTime:
+                        case PropertyValueType.Integer:
+                        case PropertyValueType.Number:
+                            document.Add(new IndexDocumentField(propertyName, propValue.Value) { IsRetrievable = true, IsFilterable = true, IsCollection = isCollection });
+                            break;
+                        case PropertyValueType.LongText:
+                            document.Add(new IndexDocumentField(propertyName, propValue.Value.ToString().ToLowerInvariant()) { IsRetrievable = true, IsSearchable = true, IsCollection = isCollection });
+                            break;
+                        case PropertyValueType.ShortText:
+                            // Index alias when it is available instead of display value.
+                            // Do not tokenize small values as they will be used for lookups and filters.
+                            var shortTextValue = propValue.Alias ?? propValue.Value.ToString();
+                            document.Add(new IndexDocumentField(propertyName, shortTextValue) { IsRetrievable = true, IsFilterable = true, IsCollection = isCollection });
+                            break;
+                        case PropertyValueType.GeoPoint:
+                            document.Add(new IndexDocumentField(propertyName, GeoPoint.TryParse((string) propValue.Value)) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
+                            break;
                     }
                 }
+
+                // Add value to the searchable content field if property type is uknown or if it is present in the provided list
+                if (property == null || contentPropertyTypes == null || contentPropertyTypes.Contains(property.Type))
+                {
+                    var contentField = string.Concat("__content", property != null && property.Multilanguage && !string.IsNullOrWhiteSpace(propValue.LanguageCode) ? "_" + propValue.LanguageCode.ToLowerInvariant() : string.Empty);
+
+                    switch (propValue.ValueType)
+                    {
+                        case PropertyValueType.LongText:
+                        case PropertyValueType.ShortText:
+                            var stringValue = propValue.Value.ToString();
+
+                            if (!string.IsNullOrWhiteSpace(stringValue)) // don't index empty values
+                            {
+                                document.Add(new IndexDocumentField(contentField, stringValue.ToLower()) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
+                            }
+
+                            break;
+                    }
+                }
+            }
         }
 
         protected virtual string[] GetOutlineStrings(IEnumerable<Outline> outlines)
@@ -80,7 +80,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
             return outlines
                 .SelectMany(ExpandOutline)
                 // VP-6151 Need to save outlines in index in lower case as we are converting search criteria outlines to lower case
-                .Select(x=>x.ToLowerInvariant())
+                .Select(x => x.ToLowerInvariant())
                 .Distinct()
                 .ToArray();
         }


### PR DESCRIPTION
### Related task:     
 VP-6151 /api/catalog/search/products not working for categoryId
### Problem:
   Search product API does not work when:
        1.  search criteria contain outline field 
        2.  any category has upper case letter in the ID field  
  because when we create outline filter ( `IFilter CreateOutlineFilter(CatalogIndexedSearchCriteria criteria)`  ) we convert outline to lowercase.

### Changes:
Convert outlines to lowercase before indexing