### PR TITLE
VP-6350: Add protection against category hierarchy cycles

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Services/CategoryMover.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/CategoryMover.cs
@@ -59,18 +59,13 @@ namespace VirtoCommerce.CatalogModule.Data.Services
 
         protected virtual async Task ValidateOperationArguments(ListEntriesMoveRequest moveInfo)
         {
-            ValidateParameters(moveInfo);
-
-            var validator = new ListEntriesMoveRequestValidator(_categoryService);
-            await validator.ValidateAndThrowAsync(moveInfo);
-        }
-
-        private void ValidateParameters(ListEntriesMoveRequest moveInfo)
-        {
             if (moveInfo == null)
             {
                 throw new ArgumentNullException(nameof(moveInfo));
             }
+
+            var validator = new ListEntriesMoveRequestValidator(_categoryService);
+            await validator.ValidateAndThrowAsync(moveInfo);
         }
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Data/Services/CategoryMover.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/CategoryMover.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -30,12 +31,29 @@ namespace VirtoCommerce.CatalogModule.Data.Services
 
         public override async Task<List<Category>> PrepareMoveAsync(ListEntriesMoveRequest moveInfo)
         {
+            if (!string.IsNullOrEmpty(moveInfo.Category))
+            {
+                var targetCategory = (await _categoryService.GetByIdsAsync(new[] { moveInfo.Category }, CategoryResponseGroup.WithOutlines.ToString())).FirstOrDefault()
+                    ?? throw new InvalidOperationException($"Destination category does not exist");
+
+                foreach (var listEntryOfTypeCategory in moveInfo.ListEntries.Where(listEntry => listEntry.Type.EqualsInvariant(CategoryListEntry.TypeName)))
+                {
+                    var movedCategoryOutline = string.Join('\\', listEntryOfTypeCategory.Outline);
+
+                    // TODO: Need to think on preventing cycles in the links, and add test
+                    if (targetCategory.Outline.StartsWith(movedCategoryOutline, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException("Cannot move category under itself");
+                    }
+                }
+            }
+
             var result = new List<Category>();
 
             foreach (var listEntryCategory in moveInfo.ListEntries.Where(
                 listEntry => listEntry.Type.EqualsInvariant(CategoryListEntry.TypeName)))
             {
-                var category = (await _categoryService.GetByIdsAsync(new [] { listEntryCategory.Id }, CategoryResponseGroup.Info.ToString())).FirstOrDefault();
+                var category = (await _categoryService.GetByIdsAsync(new[] { listEntryCategory.Id }, CategoryResponseGroup.Info.ToString())).FirstOrDefault();
                 if (category.CatalogId != moveInfo.Catalog)
                 {
                     category.CatalogId = moveInfo.Catalog;

--- a/src/VirtoCommerce.CatalogModule.Data/Services/CategoryMover.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/CategoryMover.cs
@@ -31,25 +31,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
 
         public override async Task<List<Category>> PrepareMoveAsync(ListEntriesMoveRequest moveInfo)
         {
-            if (!string.IsNullOrEmpty(moveInfo.Category))
-            {
-                var targetCategory = (await _categoryService.GetByIdsAsync(new[] { moveInfo.Category }, CategoryResponseGroup.WithOutlines.ToString())).FirstOrDefault()
-                    ?? throw new InvalidOperationException($"Destination category does not exist.");
-
-                foreach (var movedCategory in moveInfo.ListEntries.Where(x => x.Type.EqualsInvariant(CategoryListEntry.TypeName)))
-                {
-                    var movedCategoryFullPhysicalPath = string.Join("/", string.Join("/", movedCategory.Outline), movedCategory.Id);
-                    // Here we comparing that category will not be placed under itself.
-                    // E.g. we have hierarchy: Catalog1\Cat1\Cat2 - We should not allow to move Cat1 under Cat2.
-                    // Target category path - Catalog1\Cat1\Cat2, moved category path - Catalog1\Cat1.
-                    // Outlines (including virtual) of target category should not start with moved category full physical outline.
-                    // Because if moved category is a parent of a target one, it shoulld be in one of the terget category outlines.                    
-                    if (targetCategory.Outlines.Any(targetOutline => targetOutline.ToString().StartsWith(movedCategoryFullPhysicalPath)))
-                    {
-                        throw new InvalidOperationException("Cannot move category under itself");
-                    }
-                }
-            }
+            await ValidateOperationArguments(moveInfo);
 
             var result = new List<Category>();
 
@@ -71,6 +53,30 @@ namespace VirtoCommerce.CatalogModule.Data.Services
             }
 
             return result;
+        }
+
+        protected virtual async Task ValidateOperationArguments(ListEntriesMoveRequest moveInfo)
+        {
+            if (!string.IsNullOrEmpty(moveInfo.Category))
+            {
+                var targetCategory = (await _categoryService.GetByIdsAsync(new[] { moveInfo.Category }, CategoryResponseGroup.WithOutlines.ToString())).FirstOrDefault()
+                    ?? throw new InvalidOperationException($"Destination category does not exist.");
+
+                foreach (var movedCategory in moveInfo.ListEntries.Where(x => x.Type.EqualsInvariant(CategoryListEntry.TypeName)))
+                {
+                    var movedCategoryFullPhysicalPath = string.Join("/", string.Join("/", movedCategory.Outline), movedCategory.Id);
+                    // Here we comparing that category will not be placed under itself.
+                    // E.g. we have hierarchy: Catalog1\Cat1\Cat2 - We should not allow to move Cat1 under Cat2.
+                    // Target category path - Catalog1\Cat1\Cat2, moved category path - Catalog1\Cat1.
+                    // Outlines (including virtual) of target category should not be presented in moved category full physical outline.
+                    // Because if moved category is a parent of a target one, it should be in one of the terget category outlines.                    
+                    if (targetCategory.Outlines.Any(targetOutline => targetOutline.ToString().EqualsInvariant(movedCategoryFullPhysicalPath)
+                        || targetOutline.ToString().StartsWith($"{movedCategoryFullPhysicalPath}/")))
+                    {
+                        throw new InvalidOperationException("Cannot move category under itself");
+                    }
+                }
+            }
         }
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Data/Services/CategoryMover.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/CategoryMover.cs
@@ -59,13 +59,18 @@ namespace VirtoCommerce.CatalogModule.Data.Services
 
         protected virtual async Task ValidateOperationArguments(ListEntriesMoveRequest moveInfo)
         {
+            ValidateParameters(moveInfo);
+
+            var validator = new ListEntriesMoveRequestValidator(_categoryService);
+            await validator.ValidateAndThrowAsync(moveInfo);
+        }
+
+        private void ValidateParameters(ListEntriesMoveRequest moveInfo)
+        {
             if (moveInfo == null)
             {
                 throw new ArgumentNullException(nameof(moveInfo));
             }
-
-            var validator = new ListEntriesMoveRequestValidator(_categoryService);
-            await validator.ValidateAndThrowAsync(moveInfo);
         }
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Data/Services/CategoryMover.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/CategoryMover.cs
@@ -64,14 +64,15 @@ namespace VirtoCommerce.CatalogModule.Data.Services
 
                 foreach (var movedCategory in moveInfo.ListEntries.Where(x => x.Type.EqualsInvariant(CategoryListEntry.TypeName)))
                 {
-                    var movedCategoryFullPhysicalPath = string.Join("/", string.Join("/", movedCategory.Outline), movedCategory.Id);
+                    var movedCategoryPath = string.Join("/", movedCategory.Outline);
+                    var targetCategoryPath = string.Join("/", targetCategory.Outlines.FirstOrDefault());
                     // Here we comparing that category will not be placed under itself.
                     // E.g. we have hierarchy: Catalog1\Cat1\Cat2 - We should not allow to move Cat1 under Cat2.
                     // Target category path - Catalog1\Cat1\Cat2, moved category path - Catalog1\Cat1.
-                    // Outlines (including virtual) of target category should not be presented in moved category full physical outline.
-                    // Because if moved category is a parent of a target one, it should be in one of the terget category outlines.                    
-                    if (targetCategory.Outlines.Any(targetOutline => targetOutline.ToString().EqualsInvariant(movedCategoryFullPhysicalPath)
-                        || targetOutline.ToString().StartsWith($"{movedCategoryFullPhysicalPath}/")))
+                    // Target category path should not be part of moved category full physical path.
+                    // Because if moved category is a parent of a target one, it should be in target category path.                    
+                    if (targetCategoryPath.EqualsInvariant(movedCategoryPath)
+                        || targetCategoryPath.StartsWith($"{movedCategoryPath}/"))
                     {
                         throw new InvalidOperationException("Cannot move category under itself");
                     }

--- a/src/VirtoCommerce.CatalogModule.Data/Validation/ListEntriesMoveRequestValidator.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Validation/ListEntriesMoveRequestValidator.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using FluentValidation;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Model.ListEntry;
+using VirtoCommerce.CatalogModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.CatalogModule.Data.Validation
+{
+    public class ListEntriesMoveRequestValidator : AbstractValidator<ListEntriesMoveRequest>
+    {
+        private readonly ICategoryService _categoryService;
+
+        public ListEntriesMoveRequestValidator(ICategoryService categoryService)
+        {
+            _categoryService = categoryService;
+
+            RuleFor(x => x).CustomAsync(async (moveInfo, context, token) =>
+            {
+                if (string.IsNullOrEmpty(moveInfo.Category))
+                {
+                    return;
+                }
+
+                var targetCategory = (await _categoryService.GetByIdsAsync(new[] { moveInfo.Category }, CategoryResponseGroup.WithOutlines.ToString())).FirstOrDefault();
+
+                if (targetCategory == null)
+                {
+                    context.AddFailure($"Destination category does not exist.");
+                    return;
+                }
+
+                foreach (var movedCategory in moveInfo.ListEntries.Where(x => x.Type.EqualsInvariant(CategoryListEntry.TypeName)))
+                {
+                    var movedCategoryPath = string.Join("/", movedCategory.Outline);
+                    var targetCategoryPath = string.Join("/", targetCategory.Outlines.FirstOrDefault());
+                    // Here we comparing that category will not be placed under itself.
+                    // E.g. we have hierarchy: Catalog1\Cat1\Cat2 - We should not allow to move Cat1 under Cat2.
+                    // Target category path - Catalog1\Cat1\Cat2, moved category path - Catalog1\Cat1.
+                    // Target category path should not be part of moved category full physical path.
+                    // Because if moved category is a parent of a target one, it should be in target category path.                    
+                    if (targetCategoryPath.EqualsInvariant(movedCategoryPath)
+                        || targetCategoryPath.StartsWith($"{movedCategoryPath}/"))
+                    {
+                        context.AddFailure($"Cannot move category under itself.");
+                        return;
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Data/Validation/ListEntriesMoveRequestValidator.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Validation/ListEntriesMoveRequestValidator.cs
@@ -33,7 +33,7 @@ namespace VirtoCommerce.CatalogModule.Data.Validation
                 foreach (var movedCategory in moveInfo.ListEntries.Where(x => x.Type.EqualsInvariant(CategoryListEntry.TypeName)))
                 {
                     var movedCategoryPath = string.Join("/", movedCategory.Outline);
-                    var targetCategoryPath = string.Join("/", targetCategory.Outlines.FirstOrDefault());
+                    var targetCategoryPath = string.Join("/", targetCategory.CatalogId, targetCategory.Outline);
                     // Here we comparing that category will not be placed under itself.
                     // E.g. we have hierarchy: Catalog1\Cat1\Cat2 - We should not allow to move Cat1 under Cat2.
                     // Target category path - Catalog1\Cat1\Cat2, moved category path - Catalog1\Cat1.

--- a/tests/VirtoCommerce.CatalogModule.Tests/CategoryMoverTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/CategoryMoverTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Model.ListEntry;
+using VirtoCommerce.CatalogModule.Core.Services;
+using VirtoCommerce.CatalogModule.Data.Services;
+using VirtoCommerce.CoreModule.Core.Outlines;
+using VirtoCommerce.Platform.Core.Common;
+using Xunit;
+
+namespace VirtoCommerce.CatalogModule.Tests
+{
+    public class CategoryMoverTests
+    {
+        private readonly Mock<ICategoryService> _categoryServiceMock = new Mock<ICategoryService>();
+
+
+        [Theory]
+        [InlineData("Catalog/movedCat/", "Catalog")]
+        [InlineData("Catalog/movedCat/*virtual", "Catalog")]
+        [InlineData("Catalog/movedCat/child1", "Catalog")]
+        public async Task PrepareMoveAsync_PasteUnderItself_Throws(string targetCategoryOutline, string movedCategoryOutline)
+        {
+            // Arrange
+            var targetCateroryId = "targetCat";
+            var movedCateroryId = "movedCat";
+
+            MockCategoryGetById(targetCategoryOutline, targetCateroryId);
+
+            var categoryMover = new CategoryMover(_categoryServiceMock.Object);
+
+            var moveRequest = new ListEntriesMoveRequest()
+            {
+                Category = targetCateroryId,
+                ListEntries = new[]
+                {
+                    new CategoryListEntry()
+                    {
+                        Type = CategoryListEntry.TypeName,
+                        Id = movedCateroryId,
+                        Outline = movedCategoryOutline.Split("/")
+                    }
+                },
+            };
+
+            // Act
+            async Task action() => await categoryMover.PrepareMoveAsync(moveRequest);
+
+            // Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(action);
+        }
+
+        [Fact]
+        public async Task PrepareMoveAsync_PasteNotUnderItself_Passes()
+        {
+            // Arrange
+            var categoryServiceStub = new Mock<ICategoryService>();
+            var categoryMover = new CategoryMover(categoryServiceStub.Object);
+
+            // Act
+
+            // Assert
+
+        }
+
+        private void MockCategoryGetById(string outlineString, string id)
+        {
+            _categoryServiceMock
+                .Setup(x => x.GetByIdsAsync(It.Is<string[]>(ids => ids.Length == 1 && ids[0].EqualsInvariant(id)), It.IsAny<string>(), null))
+                .Returns(Task.FromResult(new[] {
+                    new Category()
+                    {
+                        Outlines = new []
+                        {
+                            new Outline()
+                            {
+                                Items = outlineString.Split("/", StringSplitOptions.RemoveEmptyEntries)
+                                    .Select( part =>
+                                        new OutlineItem()
+                                        {
+                                            Id = part
+                                        })
+                                    .ToList()
+                            }
+                        }
+                    }
+                }));
+        }
+    }
+}

--- a/tests/VirtoCommerce.CatalogModule.Tests/CategoryMoverTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/CategoryMoverTests.cs
@@ -15,8 +15,6 @@ namespace VirtoCommerce.CatalogModule.Tests
     public class CategoryMoverTests
     {
         private readonly Mock<ICategoryService> _categoryServiceMock = new Mock<ICategoryService>();
-        private readonly string _targetCateroryId = "targetCat";
-        private readonly string _movedCateroryId = "movedCat";
         private readonly CategoryMover _categoryMover;
 
         public CategoryMoverTests()
@@ -25,26 +23,28 @@ namespace VirtoCommerce.CatalogModule.Tests
         }
 
         [Theory]
-        [InlineData("Catalog/movedCat", "Catalog")]
-        [InlineData("Catalog/movedCat/", "Catalog")]
-        [InlineData("Catalog/movedCat/*virtual", "Catalog")]
-        [InlineData("Catalog/movedCat/child1", "Catalog")]
-        [InlineData("Catalog/*virtual/movedCat", "Catalog/*virtual")]
-        public async Task PrepareMoveAsync_PasteUnderItself_Throws(string targetCategoryOutline, string movedCategoryOutline)
+        [InlineData("Catalog/movedCat/targetCat", "Catalog/movedCat")]
+        [InlineData("Catalog/movedCat/*virtual/targetCat", "Catalog/movedCat")]
+        [InlineData("Catalog/movedCat/child1/targetCat", "Catalog/movedCat")]
+        [InlineData("Catalog/*virtual/movedCat/targetCat", "Catalog/*virtual/movedCat")]
+        public async Task PrepareMoveAsync_PasteUnderItself_Throws(string targetCategoryPath, string movedCategoryPath)
         {
             // Arrange
-            MockCategoryGetById(targetCategoryOutline, _targetCateroryId);
+            var targetCateroryId = targetCategoryPath.Split("/").Last();
+            var movedCateroryId = movedCategoryPath.Split("/").Last();
+
+            MockCategoryGetById(targetCategoryPath, targetCateroryId);
 
             var moveRequest = new ListEntriesMoveRequest()
             {
-                Category = _targetCateroryId,
+                Category = targetCateroryId,
                 ListEntries = new[]
                 {
                     new CategoryListEntry()
                     {
                         Type = CategoryListEntry.TypeName,
-                        Id = _movedCateroryId,
-                        Outline = movedCategoryOutline.Split("/")
+                        Id = movedCateroryId,
+                        Outline = movedCategoryPath.Split("/")
                     }
                 },
             };
@@ -57,25 +57,28 @@ namespace VirtoCommerce.CatalogModule.Tests
         }
 
         [Theory]
-        [InlineData("Catalog/movedCat2", "Catalog")]
-        [InlineData("Catalog/anyOtherCat", "Catalog")]
-        [InlineData("DifferentCatalog/movedCat/child1", "Catalog")]
-        public async Task PrepareMoveAsync_PasteNotUnderItself_Passes(string targetCategoryOutline, string movedCategoryOutline)
+        [InlineData("Catalog/movedCat2/targetCat", "Catalog/movedCat")]
+        [InlineData("Catalog/anyOtherCat/targetCat", "Catalog/movedCat")]
+        [InlineData("DifferentCatalog/movedCat/child1/targetCat", "Catalog/movedCat")]
+        public async Task PrepareMoveAsync_PasteNotUnderItself_Passes(string targetCategoryPath, string movedCategoryPath)
         {
             // Arrange
-            MockCategoryGetById(targetCategoryOutline, _targetCateroryId);
-            MockCategoryGetById(movedCategoryOutline, _movedCateroryId);
+            var targetCateroryId = targetCategoryPath.Split("/").Last();
+            var movedCateroryId = movedCategoryPath.Split("/").Last();
+
+            MockCategoryGetById(targetCategoryPath, targetCateroryId);
+            MockCategoryGetById(movedCategoryPath, movedCateroryId);
 
             var moveRequest = new ListEntriesMoveRequest()
             {
-                Category = _targetCateroryId,
+                Category = targetCateroryId,
                 ListEntries = new[]
                 {
                     new CategoryListEntry()
                     {
                         Type = CategoryListEntry.TypeName,
-                        Id = _movedCateroryId,
-                        Outline = movedCategoryOutline.Split("/")
+                        Id = movedCateroryId,
+                        Outline = movedCategoryPath.Split("/")
                     }
                 },
             };
@@ -88,7 +91,7 @@ namespace VirtoCommerce.CatalogModule.Tests
 
         }
 
-        private void MockCategoryGetById(string outlineString, string id)
+        private void MockCategoryGetById(string path, string id)
         {
             _categoryServiceMock
                 .Setup(x => x.GetByIdsAsync(It.Is<string[]>(ids => ids.Length == 1 && ids[0].EqualsInvariant(id)), It.IsAny<string>(), null))
@@ -99,7 +102,7 @@ namespace VirtoCommerce.CatalogModule.Tests
                         {
                             new Outline()
                             {
-                                Items = outlineString.Split("/", StringSplitOptions.RemoveEmptyEntries)
+                                Items = path.Split("/", StringSplitOptions.RemoveEmptyEntries)
                                     .Select( part =>
                                         new OutlineItem()
                                         {


### PR DESCRIPTION
Moving categories to its children is prohibited now.