### PR TITLE
VP-6051: Fix product indexation bug: search names for outline items

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/CatalogDocumentBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/CatalogDocumentBuilder.cs
@@ -49,7 +49,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
                                 document.Add(new IndexDocumentField(propertyName, shortTextValue) { IsRetrievable = true, IsFilterable = true, IsCollection = isCollection });
                                 break;
                             case PropertyValueType.GeoPoint:
-                                document.Add(new IndexDocumentField(propertyName, GeoPoint.TryParse((string) propValue.Value)) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
+                                document.Add(new IndexDocumentField(propertyName, GeoPoint.TryParse((string)propValue.Value)) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
                                 break;
                         }
                     }
@@ -91,13 +91,13 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
 
             var items = outline.Items
                 .Take(outline.Items.Count - 1) // Exclude last item, which is current item ID
-                // VP-6151 Need to save outlines in index in lower case as we are converting search criteria outlines to lower case
+                                               // VP-6151 Need to save outlines in index in lower case as we are converting search criteria outlines to lower case
                 .Select(i => i.Id.ToLowerInvariant())
                 .ToList();
 
             var itemNames = outline.Items
                 .Take(outline.Items.Count - 1) // Exclude last item, which is current item ID
-                .ToDictionary(x => x.Id, y => y.Name);
+                .ToDictionary(x => x.Id.ToLowerInvariant(), y => y.Name);
 
             var result = new List<string>();
 

--- a/tests/VirtoCommerce.CatalogModule.Tests/CatalogDocumentBuilderTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/CatalogDocumentBuilderTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Moq;
 using VirtoCommerce.CatalogModule.Core;
 using VirtoCommerce.CatalogModule.Data.Search.Indexing;
@@ -21,6 +22,26 @@ namespace VirtoCommerce.CatalogModule.Tests
 
             //Assert
             Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void OutlinesInLowercase()
+        {
+            //Arrange
+            var builder = GetFakeCatalogDocumentBuilder();
+
+            //Act
+            var outlines = new[] { new Outline
+                        {
+                            Items = new[] {
+                                new OutlineItem { Id = "C", Name = "catalog" },
+                                new OutlineItem { Id = "C1", Name = "category1" },
+                                new OutlineItem { Id = "P1", Name = "product1" },
+                            } } };
+            var result = builder.GetOutlineStringsPublic(outlines, true);
+
+            //Assert
+            Assert.DoesNotContain(result, outline => outline.Any(c => char.IsUpper(c)));
         }
 
         private FakeCatalogDocumentBuilder GetFakeCatalogDocumentBuilder()

--- a/tests/VirtoCommerce.CatalogModule.Tests/CatalogDocumentBuilderTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/CatalogDocumentBuilderTests.cs
@@ -25,19 +25,20 @@ namespace VirtoCommerce.CatalogModule.Tests
         }
 
         [Fact]
-        public void OutlinesInLowercase()
+        public void GetOutlineStrings_SomeIdsContainUppercasedChars_OutlinesMustBeInLowercase()
         {
             //Arrange
             var builder = GetFakeCatalogDocumentBuilder();
-
-            //Act
             var outlines = new[] { new Outline
                         {
                             Items = new[] {
                                 new OutlineItem { Id = "C", Name = "catalog" },
                                 new OutlineItem { Id = "C1", Name = "category1" },
+                                new OutlineItem { Id = "S1", Name = "subcategory1" },
                                 new OutlineItem { Id = "P1", Name = "product1" },
                             } } };
+
+            //Act
             var result = builder.GetOutlineStringsPublic(outlines, true);
 
             //Assert


### PR DESCRIPTION
That fixes outline items names search. Item ids used lowercased, but by some mistake, ids for names not.