### PR TITLE
VP-6721: Fix category property does not show when exist product property with same name 

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/Model/Category.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/Category.cs
@@ -125,12 +125,10 @@ namespace VirtoCommerce.CatalogModule.Core.Model
                     {
                         continue;
                     }
-                    if (Properties == null)
-                    {
-                        Properties = new List<Property>();
-                    }
+
+                    Properties ??= new List<Property>();
                     //Try to find property by type and name
-                    var existProperty = Properties.FirstOrDefault(x => x.IsSame(parentProperty, PropertyType.Product, PropertyType.Variation));
+                    var existProperty = Properties.FirstOrDefault(x => x.IsSame(parentProperty));
                     if (existProperty == null)
                     {
                         existProperty = AbstractTypeFactory<Property>.TryCreateInstance();
@@ -140,19 +138,13 @@ namespace VirtoCommerce.CatalogModule.Core.Model
                     existProperty.IsReadOnly = existProperty.Type != PropertyType.Category;
                 }
                 //Restore order after changes
-                if (Properties != null)
-                {
-                    Properties = Properties.OrderBy(x => x.Name).ToList();
-                }
+                Properties = Properties?.OrderBy(x => x.Name).ToList();
             }
 
             if (parent is IHasTaxType hasTaxType)
             {
                 //Try to inherit taxType from parent category
-                if (TaxType == null)
-                {
-                    TaxType = hasTaxType.TaxType;
-                }
+                TaxType ??= hasTaxType.TaxType;
             }
         }
         #endregion


### PR DESCRIPTION
### Related task:     
VP-6721 Properties/Parent properties of categories with the same name but different PropertyType are considered as same
### Problem:
If a Catalog has defined a Category property and Product property with the same name and same ValueType but different PropertyType they are considered as same when the Category is fetched (ResponseGroup.Full) and therefore only one is returned under Category.Properties (the one with PropertyType.Product).
### Solution:
Remove additional types



