### PR TITLE
VP-6852 Add infinite scroll for catalog and priselist selectors

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/Model/Search/CatalogSearchCriteria.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/Search/CatalogSearchCriteria.cs
@@ -1,9 +1,14 @@
+using System.Linq;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.CatalogModule.Core.Model.Search
 {
     public class CatalogSearchCriteria : SearchCriteriaBase
     {
-        public string[] CatalogIds { get; set; }
+        public string[] CatalogIds
+        {
+            get => ObjectIds.ToArray();
+            set => ObjectIds = value;
+        }
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Core/Model/Search/CatalogSearchCriteria.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/Search/CatalogSearchCriteria.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -7,7 +8,7 @@ namespace VirtoCommerce.CatalogModule.Core.Model.Search
     {
         public string[] CatalogIds
         {
-            get => ObjectIds.ToArray();
+            get => ObjectIds?.ToArray() ?? Array.Empty<string>();
             set => ObjectIds = value;
         }
     }

--- a/src/VirtoCommerce.CatalogModule.Data/Search/CatalogSearchService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/CatalogSearchService.cs
@@ -56,9 +56,9 @@ namespace VirtoCommerce.CatalogModule.Data.Search
             {
                 query = query.Where(x => x.Name.Contains(criteria.Keyword));
             }
-            if (!criteria.CatalogIds.IsNullOrEmpty())
+            if (!criteria.ObjectIds.IsNullOrEmpty())
             {
-                query = query.Where(x => criteria.CatalogIds.Contains(x.Id));
+                query = query.Where(x => criteria.ObjectIds.Contains(x.Id));
             }
             return query;
         }


### PR DESCRIPTION
### Related task:     
VP-6852: Set new pricelist assignments are only possible for the first 20 catalogues
### Problem:
 We could not use a generic directive for UI scroll because property ObjectIds doesn't work in some *SearchCriteria
### Solution:
Fix search by ObjectIds
### Changes:
Use already existing ObjectIds for added it SearchCriteria the CatalogIds property.