### PR TITLE
PT-3388 Skip property name validation for itself

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-detail.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-detail.js
@@ -43,6 +43,7 @@ angular.module('virtoCommerce.catalogModule')
             }
 
             // validation for category properties
+            // skips backend property name validation for current entity edit when the old name equals new name
             if (!blade.origEntity.categoryId || (!blade.origEntity.isNew && value === blade.origEntity.name)) {
                 $scope.errorData = null;
                 return $q.resolve();

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-detail.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-detail.js
@@ -43,7 +43,7 @@ angular.module('virtoCommerce.catalogModule')
             }
 
             // validation for category properties
-            if (!blade.origEntity.categoryId) {
+            if (!blade.origEntity.categoryId || (!blade.origEntity.isNew && value === blade.origEntity.name)) {
                 $scope.errorData = null;
                 return $q.resolve();
             }


### PR DESCRIPTION
## Description
Skipping validation for the same name is the property details is opened for edit and the new name = old name
## References
### QA-test: PT-3389
### Jira-link: https://virtocommerce.atlassian.net/browse/PT-3387
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.63.0-pr-541.zip
