### PR TITLE
PT-4230 Fix error. 'api/catalog/listentries' return the wrong total count at keyword searching

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
@@ -317,9 +317,10 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
                 var take = Math.Min(criteria.Take, Math.Max(0, totalCount - criteria.Skip));
 
                 result.Results = catIndexedSearchResult.Items.Select(x => AbstractTypeFactory<CategoryListEntry>.TryCreateInstance().FromModel(x)).ToList();
+                result.TotalCount = (int)totalCount;
 
-                criteria.Skip -= (int) skip;
-                criteria.Take -= (int) take;
+                criteria.Skip -= (int)skip;
+                criteria.Take -= (int)take;
 
                 const ItemResponseGroup itemResponseGroup = ItemResponseGroup.ItemInfo | ItemResponseGroup.Outlines;
 


### PR DESCRIPTION
### Description

### References
#### QA-test:
#### Jira-link: https://virtocommerce.atlassian.net/browse/PT-4230
#### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.64.0-pr-547.zip
