### PR TITLE
PT-4117: Rework units of measurement

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/en.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/en.VirtoCommerce.Catalog.json
@@ -324,6 +324,8 @@
           "package-type": "Package type",
           "weight-unit": "Mass units",
           "weight": "Weight",
+          "dimensions": "Dimensions",
+          "use-package-type": "Use from package type",
           "measure-unit": "Units of length",
           "max-downloads": "Maximum downloads",
           "expiration-date": "Download expiration date",
@@ -548,8 +550,8 @@
         "title": "Search results"
       },
       "item-dimensions": {
-        "title": "Item dimensions",
-        "subtitle": "change product size & weight here"
+        "title": "Item measurement",
+        "subtitle": "Change product measurement properties"
       },
       "asset-select": {
         "title": "Link images"

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/ru.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/ru.VirtoCommerce.Catalog.json
@@ -283,6 +283,8 @@
           "package-type": "Тип упаковки",
           "weight-unit": "Единица веса",
           "weight": "Вес",
+          "dimensions": "Размер",
+          "use-package-type": "Как у типа упаковки",
           "measure-unit": "Единица длины",
           "max-downloads": "Максимум скачиваний",
           "expiration-date": "Дата истечения срока действия",

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/item-dimensions.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/item-dimensions.js
@@ -1,84 +1,97 @@
-﻿angular.module('virtoCommerce.catalogModule')
+angular.module('virtoCommerce.catalogModule')
 .controller('virtoCommerce.catalogModule.itemDimensionController', ['$scope', 'platformWebApp.bladeNavigationService', 'platformWebApp.settings', 'virtoCommerce.catalogModule.items', 'virtoCommerce.customerModule.members', 'virtoCommerce.coreModule.packageType.packageTypeUtils', function ($scope, bladeNavigationService, settings, items, members, packageTypeUtils) {
-	var blade = $scope.blade;
-	blade.title = 'catalog.blades.item-dimensions.title';
-	blade.subtitle = 'catalog.blades.item-dimensions.subtitle';
-	blade.isLoading = false;
-	$scope.isValid = false;
+    var blade = $scope.blade;
+    blade.title = 'catalog.blades.item-dimensions.title';
+    blade.subtitle = 'catalog.blades.item-dimensions.subtitle';
+    blade.isLoading = false;
+    $scope.isValid = false;
 
-	var formScope;
-	$scope.setForm = function (form) {
-		formScope = form;
-	}
+    var formScope;
+    $scope.setForm = function (form) {
+        formScope = form;
+    }
 
-	$scope.$watch("blade.currentEntity", function () {
-		$scope.isValid = formScope && formScope.$valid;
-	}, true);
+    $scope.$watch("blade.currentEntity", function () {
+        $scope.isValid = formScope && formScope.$valid;
+    }, true);
 
-	blade.refresh = function (item) {
-		if (item) {
-			initialize(item);
-		}	
-	};
-	function initalize(item) {
-		blade.item = item;
+    blade.refresh = function (item) {
+        if (item) {
+            initialize(item);
+        }	
+    };
+    function initalize(item) {
+        $scope.packageTypeUtils = packageTypeUtils;
+        $scope.packageTypes = packageTypeUtils.getPackageTypes();
 
-		blade.currentEntity = {
-			weightUnit : item.weightUnit,
-			packageType : item.packageType,
-			weight : item.weight,
-			measureUnit : item.measureUnit,
-			height : item.height,
-			width : item.width,
-			length : item.length
-		};
+        blade.item = item;
 
-		$scope.weightUnits = settings.getValues({ id: 'VirtoCommerce.Core.General.WeightUnits' });
-		$scope.measureUnits = settings.getValues({ id: 'VirtoCommerce.Core.General.MeasureUnits' });
-		$scope.packageTypeUtils = packageTypeUtils;
-		$scope.packageTypes = packageTypeUtils.getPackageTypes()
-	};
+        blade.currentEntity = {
+            weightUnit : item.weightUnit,
+            packageType : item.packageType,
+            weight : item.weight,
+            measureUnit : item.measureUnit,
+            height : item.height,
+            width : item.width,
+            length: item.length,
+            usePackageType: item.packageType && !(item.measureUnit && item.height && item.width && item.length)
+        };
 
-	$scope.saveChanges = function () {
-		angular.extend(blade.item, blade.currentEntity);
-		$scope.bladeClose();
-	};
-	
-    $scope.openDictionarySettingManagement = function (setting) {
-    	var newBlade = {
-    		id: 'settingDetailChild',
-    		isApiSave: true,
-    		controller: 'platformWebApp.settingDictionaryController',
-    		template: '$(Platform)/Scripts/app/settings/blades/setting-dictionary.tpl.html'
-    	};
-    	switch (setting) {
-    		case 'WeightUnits':
-    			_.extend(newBlade, {
-    				currentEntityId: 'VirtoCommerce.Core.General.WeightUnits',
-    				parentRefresh: function (data) { $scope.weightUnits = data; }
-    			});
-    			break;
-    		case 'MeasureUnits':
-    			_.extend(newBlade, {
-    				currentEntityId: 'VirtoCommerce.Core.General.MeasureUnits',
-    				parentRefresh: function (data) { $scope.measureUnits = data; }
-    			});
-    			break;
-    	}
-
-    	bladeNavigationService.showBlade(newBlade, blade);
+        $scope.weightUnits = settings.getValues({ id: 'VirtoCommerce.Core.General.WeightUnits' });
+        $scope.measureUnits = settings.getValues({ id: 'VirtoCommerce.Core.General.MeasureUnits' });        
     };
 
-    $scope.$watch('blade.item.packageType', function (packageTypeId) {
-    	if (packageTypeId) {
-    		var packageType = _.find($scope.packageTypes, function (x) { return x.id == packageTypeId; });
-    		if (packageType) {
-    			blade.item.measureUnit = packageType.measureUnit;
-    			blade.item.length = packageType.length;
-    			blade.item.width = packageType.width;
-    			blade.item.height = packageType.height;
-    		}
-    	}
+    $scope.saveChanges = function () {
+        angular.extend(blade.item, blade.currentEntity);
+        if (blade.item.usePackageType) {
+            delete blade.item.measureUnit;
+            delete blade.item.height;
+            delete blade.item.width;
+            delete blade.item.length;
+        }
+        $scope.bladeClose();
+    };
+    
+    $scope.openDictionarySettingManagement = function (setting) {
+        var newBlade = {
+            id: 'settingDetailChild',
+            isApiSave: true,
+            controller: 'platformWebApp.settingDictionaryController',
+            template: '$(Platform)/Scripts/app/settings/blades/setting-dictionary.tpl.html'
+        };
+        switch (setting) {
+            case 'WeightUnits':
+                _.extend(newBlade, {
+                    currentEntityId: 'VirtoCommerce.Core.General.WeightUnits',
+                    parentRefresh: function (data) { $scope.weightUnits = data; }
+                });
+                break;
+            case 'MeasureUnits':
+                _.extend(newBlade, {
+                    currentEntityId: 'VirtoCommerce.Core.General.MeasureUnits',
+                    parentRefresh: function (data) { $scope.measureUnits = data; }
+                });
+                break;
+        }
+
+        bladeNavigationService.showBlade(newBlade, blade);
+    };
+
+    $scope.$watch('blade.currentEntity.packageType', function (packageTypeId) {
+        if (!packageTypeId) {
+            blade.currentEntity.usePackageType = false;
+        }
+    });
+
+    $scope.$watch('blade.currentEntity.usePackageType', function (usePackageTypeValue) {
+        if (!usePackageTypeValue) {
+            if (!blade.currentEntity.measureUnit) {
+                var packageType = _.find($scope.packageTypes, function (x) { return x.id == blade.currentEntity.packageType; });
+                if (packageType) {
+                    blade.currentEntity.measureUnit = packageType.measureUnit;
+                }
+            }
+        }
     });
 
     initalize(blade.item);

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/item-dimensions.tpl.html
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/item-dimensions.tpl.html
@@ -1,9 +1,12 @@
-﻿<div class="blade-static __bottom" ng-include="'Modules/$(VirtoCommerce.Catalog)/Scripts/blades/common/templates/ok-cancel.tpl.html'"></div>
+<div class="blade-static __bottom" ng-include="'Modules/$(VirtoCommerce.Catalog)/Scripts/blades/common/templates/ok-cancel.tpl.html'"></div>
 <div class="blade-content __medium-wide">
     <div class="blade-inner">
         <div class="inner-block">
             <form name="dimensionsForm" class="form">
-                <div class="form-group"  ng-init="setForm(dimensionsForm)">
+                <div class="form-group clearfix" ng-init="setForm(dimensionsForm)">
+                    <fieldset>
+                        <legend>{{ 'catalog.blades.item-detail.labels.weight' | translate }}</legend>
+                    </fieldset>
                     <div class="columns">
                         <div class="column">
                             <div class="form-group">
@@ -17,6 +20,23 @@
                                     </ui-select>
                                 </div>
                             </div>
+                        </div>
+                        <div class="column">
+                            <div class="form-group">
+                                <label class="form-label">{{ 'catalog.blades.item-detail.labels.weight' | translate }}</label>
+                                <div class="form-input __number">
+                                    <input smart-float num-type="float" min="0.0" ng-model="blade.currentEntity.weight" placeholder="{{ 'catalog.blades.item-detail.placeholders.weight' | translate}}" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group clearfix">
+                    <fieldset>
+                        <legend>{{ 'catalog.blades.item-detail.labels.dimensions' | translate }}</legend>
+                    </fieldset>
+                    <div class="columns">
+                        <div class="column">
                             <div class="form-group">
                                 <label class="form-label">{{ 'catalog.blades.item-detail.labels.package-type' | translate }} <a href="" ng-click="packageTypeUtils.editPackageTypes(blade)" class="form-edit" va-permission="platform:setting:update"><i class="form-ico fa fa-pencil"></i></a></label>
                                 <div class="form-input">
@@ -28,56 +48,51 @@
                                     </ui-select>
                                 </div>
                             </div>
-                        </div>
-                        <div class="column">
                             <div class="form-group">
-                                <label class="form-label">{{ 'catalog.blades.item-detail.labels.weight' | translate }}</label>
-                                <div class="form-input __number">
-                                    <input smart-float num-type="float" min="0.0" ng-model="blade.currentEntity.weight" placeholder="{{ 'catalog.blades.item-detail.placeholders.weight' | translate}}" />
-                                </div>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">{{ 'catalog.blades.item-detail.labels.measure-unit' | translate }} <a href="" ng-click="openDictionarySettingManagement('MeasureUnits')" class="form-edit" va-permission="platform:setting:update"><i class="form-ico fa fa-pencil"></i></a></label>
+                                <label class="form-label">{{'catalog.blades.item-detail.labels.use-package-type' | translate}}</label>
                                 <div class="form-input">
-                                    <ui-select ng-model="blade.currentEntity.measureUnit">
-                                        <ui-select-match allow-clear="true" placeholder="N/A">{{$select.selected}}</ui-select-match>
-                                        <ui-select-choices repeat="x in measureUnits | filter: $select.search">
-                                            <span ng-bind-html="x | highlight: $select.search"></span>
-                                        </ui-select-choices>
-                                    </ui-select>
+                                    <label class="form-label __switch">
+                                        <input type="checkbox" ng-model="blade.currentEntity.usePackageType" ng-disabled="!blade.currentEntity.packageType"/>
+                                        <span class="switch"></span>
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="column">
+                            <div ng-if="!blade.currentEntity.usePackageType">
+                                <div class="form-group">
+                                    <label class="form-label">{{ 'catalog.blades.item-detail.labels.measure-unit' | translate }} <a href="" ng-click="openDictionarySettingManagement('MeasureUnits')" class="form-edit" va-permission="platform:setting:update"><i class="form-ico fa fa-pencil"></i></a></label>
+                                    <div class="form-input">
+                                        <ui-select ng-model="blade.currentEntity.measureUnit">
+                                            <ui-select-match allow-clear="true" placeholder="N/A">{{$select.selected}}</ui-select-match>
+                                            <ui-select-choices repeat="x in measureUnits | filter: $select.search">
+                                                <span ng-bind-html="x | highlight: $select.search"></span>
+                                            </ui-select-choices>
+                                        </ui-select>
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">{{'catalog.widgets.itemDimensions.height' | translate}}</label>
+                                    <div class="form-input __number">
+                                        <input num-type="float" min="0.0" smart-float fraction="3" ng-model="blade.currentEntity.height" placeholder="N/A" />
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">{{'catalog.widgets.itemDimensions.width' | translate}}</label>
+                                    <div class="form-input __number">
+                                        <input smart-float num-type="float" min="0.0" fraction="3" ng-model="blade.currentEntity.width" placeholder="N/A" />
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">{{'catalog.widgets.itemDimensions.length' | translate}}</label>
+                                    <div class="form-input __number">
+                                        <input smart-float num-type="float" min="0.0" fraction="3" ng-model="blade.currentEntity.length" placeholder="N/A" />
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="form-group">
-                    <div class="columns">
-                        <div class="column">
-                            <div class="form-group">
-                                <label class="form-label">{{'catalog.widgets.itemDimensions.height' | translate}}</label>
-                                <div class="form-input __number">
-                                  <input num-type="float" min="0.0" smart-float ng-model="blade.currentEntity.height" placeholder="N/A" />
-                                </div>
-                            </div>
-                        </div>
-                        <div class="column">
-                            <div class="form-group">
-                                <label class="form-label">{{'catalog.widgets.itemDimensions.width' | translate}}</label>
-                                <div class="form-input __number">
-                                    <input smart-float num-type="float" min="0.0" ng-model="blade.currentEntity.width" placeholder="N/A" />
-                                </div>
-                            </div>
-                        </div>
-                        <div class="column">
-                            <div class="form-group">
-                                <label class="form-label">{{'catalog.widgets.itemDimensions.length' | translate}}</label>
-                                <div class="form-input __number">
-                                    <input smart-float num-type="float" min="0.0" ng-model="blade.currentEntity.length" placeholder="N/A" />
-                                </div>
-                            </div>
-                        </div>                    
                     </div>
-                </div>
             </form>
         </div>
     </div>

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/widgets/itemDimensionWidget.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/widgets/itemDimensionWidget.js
@@ -1,5 +1,5 @@
-﻿angular.module('virtoCommerce.catalogModule')
-.controller('virtoCommerce.catalogModule.itemDimensionWidgetController', ['$scope', 'virtoCommerce.catalogModule.items', 'platformWebApp.bladeNavigationService', function ($scope, items, bladeNavigationService) {
+angular.module('virtoCommerce.catalogModule')
+    .controller('virtoCommerce.catalogModule.itemDimensionWidgetController', ['$scope', 'virtoCommerce.catalogModule.items', 'platformWebApp.bladeNavigationService', 'virtoCommerce.coreModule.packageType.packageTypeApi', function ($scope, items, bladeNavigationService, packageTypeApi) {
 
     $scope.openBlade = function () {
         var blade = {
@@ -10,5 +10,16 @@
         };
         bladeNavigationService.showBlade(blade, $scope.blade);
     };
-  
+
+    $scope.$watch('blade.item.packageType', function (packageTypeId) {
+        if (packageTypeId) {
+            packageTypeApi.query({}, function (results) {
+                $scope.blade.packageType = _.find(results, function (x) { return x.id == packageTypeId; });
+            });
+        }
+        else {
+            delete $scope.blade.packageType;
+        }
+    });  
+
 }]);

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/widgets/itemDimensionWidget.tpl.html
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/widgets/itemDimensionWidget.tpl.html
@@ -1,8 +1,8 @@
-﻿<div class="gridster-cnt" ng-click="openBlade()">
+<div class="gridster-cnt" ng-click="openBlade()">
     <ul class="list __stats">
-        <li class="list-item">{{'catalog.widgets.itemDimensions.height' | translate}} <span class="list-price">{{blade.item.height ? (blade.item.height | number) : 'N/A' }} {{blade.item.measureUnit}}</span></li>
-        <li class="list-item">{{'catalog.widgets.itemDimensions.width' | translate}} <span class="list-price">{{blade.item.width ? (blade.item.width | number) : 'N/A' }} {{blade.item.measureUnit}}</span></li>
-        <li class="list-item">{{'catalog.widgets.itemDimensions.length' | translate}} <span class="list-price">{{blade.item.length ? (blade.item.length | number) : 'N/A' }} {{blade.item.measureUnit}}</span></li>
+        <li class="list-item">{{'catalog.widgets.itemDimensions.height' | translate}} <span class="list-price">{{blade.item.height ? (blade.item.height | number) : (blade.packageType ? (blade.packageType.height | number) : 'N/A' )}} {{blade.item.measureUnit ? blade.item.measureUnit : (blade.packageType ? blade.packageType.measureUnit : '')}}</span></li>
+        <li class="list-item">{{'catalog.widgets.itemDimensions.width' | translate}} <span class="list-price">{{blade.item.width ? (blade.item.width | number) : (blade.packageType ? (blade.packageType.width | number) : 'N/A' ) }} {{blade.item.measureUnit ? blade.item.measureUnit : (blade.packageType ? blade.packageType.measureUnit : '')}}</span></li>
+        <li class="list-item">{{'catalog.widgets.itemDimensions.length' | translate}} <span class="list-price">{{blade.item.length ? (blade.item.length | number) : (blade.packageType ? (blade.packageType.length | number) : 'N/A' ) }} {{blade.item.measureUnit ? blade.item.measureUnit : (blade.packageType ? blade.packageType.measureUnit : '')}}</span></li>
         <li class="list-item">{{'catalog.widgets.itemDimensions.weight' | translate }} <span class="list-price">{{blade.item.weight ? (blade.item.weight | number) : 'N/A'}} {{blade.item.weightUnit}} </span></li>
     </ul>
 </div>


### PR DESCRIPTION
## Description
Rework units of measurement for the product:
1. Dimension values not copied anymore from package to product;
2. Add **Use from package type** option to evidently set dimensions from the package;
![image](https://user-images.githubusercontent.com/9972421/140064179-6d9a9848-c7b3-4898-8b9f-e1d8ff391574.png)
![image](https://user-images.githubusercontent.com/9972421/140064415-09166656-03f9-4631-96e6-1ce80e6d8ca9.png)
3. Weight/size widget correctly shows data from the product or package depending on the setting.
![image](https://user-images.githubusercontent.com/9972421/140064733-cc2ea196-0f15-4d9f-9b7a-41f042cf80d6.png)
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4117
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.74.0-pr-569.zip
