### PR TITLE
PT-5136: Long text can’t exist with dictionary option

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-detail.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-detail.js
@@ -30,6 +30,9 @@ angular.module('virtoCommerce.catalogModule')
                     blade.hasDictionary = blade.currentEntity.dictionary = false;
                     blade.hasMultilanguage = blade.currentEntity.multilanguage = false;
                     break;
+                case 'LongText':
+                    blade.hasDictionary = blade.currentEntity.dictionary = false;
+                    break;
             }
         });
 


### PR DESCRIPTION
## Description
Long text can’t exist with dictionary option
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-5136
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.76.0-pr-571.zip
