### PR TITLE
PT-6005: Inconsistent AggregationSize default value - additional improvements

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/ModuleConstants.cs
@@ -9,6 +9,7 @@ namespace VirtoCommerce.CatalogModule.Core
     [ExcludeFromCodeCoverage]
     public static class ModuleConstants
     {
+        public static int DefaultAggregationSize = 25;
         public static class Security
         {
             public static class Permissions
@@ -152,7 +153,7 @@ namespace VirtoCommerce.CatalogModule.Core
                     Name = "Catalog.Search.DefaultAggregationSize",
                     GroupName = "Catalog|Search",
                     ValueType = SettingValueType.Integer,
-                    DefaultValue = 25
+                    DefaultValue = ModuleConstants.DefaultAggregationSize
                 };
 
                 public static IEnumerable<SettingDescriptor> AllSettings

--- a/src/VirtoCommerce.CatalogModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/ModuleConstants.cs
@@ -31,6 +31,7 @@ namespace VirtoCommerce.CatalogModule.Core
 
         public static class Settings
         {
+#pragma warning disable S3218
             public static class General
             {
                 public static SettingDescriptor CopyIDMenuItem { get; } = new SettingDescriptor
@@ -146,6 +147,14 @@ namespace VirtoCommerce.CatalogModule.Core
                     DefaultValue = default(DateTime)
                 };
 
+                public static SettingDescriptor DefaultAggregationSize { get; } = new SettingDescriptor
+                {
+                    Name = "Catalog.Search.DefaultAggregationSize",
+                    GroupName = "Catalog|Search",
+                    ValueType = SettingValueType.Integer,
+                    DefaultValue = 25
+                };
+
                 public static IEnumerable<SettingDescriptor> AllSettings
                 {
                     get
@@ -154,6 +163,7 @@ namespace VirtoCommerce.CatalogModule.Core
                         yield return UseFullObjectIndexStoring;
                         yield return IndexationDateProduct;
                         yield return IndexationDateCategory;
+                        yield return DefaultAggregationSize;
                     }
                 }
             }
@@ -165,6 +175,7 @@ namespace VirtoCommerce.CatalogModule.Core
                     return General.AllSettings.Concat(Search.AllSettings);
                 }
             }
+#pragma warning restore S3218
         }
 
         public const string OutlineDelimiter = "___";

--- a/src/VirtoCommerce.CatalogModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/ModuleConstants.cs
@@ -9,7 +9,7 @@ namespace VirtoCommerce.CatalogModule.Core
     [ExcludeFromCodeCoverage]
     public static class ModuleConstants
     {
-        public static int DefaultAggregationSize = 25;
+        public const int DefaultAggregationSize = 25;
         public static class Security
         {
             public static class Permissions

--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogBrowseFiltersController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogBrowseFiltersController.cs
@@ -13,6 +13,7 @@ using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.CatalogModule.Data.Search.BrowseFilters;
 using VirtoCommerce.CatalogModule.Web.Model;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.StoreModule.Core.Services;
 
@@ -31,17 +32,21 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
         private readonly IPropertyService _propertyService;
         private readonly IBrowseFilterService _browseFilterService;
         private readonly IPropertyDictionaryItemSearchService _propDictItemsSearchService;
+        private readonly ISettingsManager _settingsManager;
+
 
         public CatalogBrowseFiltersController(
             IStoreService storeService
             , IPropertyService propertyService
             , IBrowseFilterService browseFilterService
-            , IPropertyDictionaryItemSearchService propDictItemsSearchService)
+            , IPropertyDictionaryItemSearchService propDictItemsSearchService
+            , ISettingsManager settingsManager)
         {
             _storeService = storeService;
             _propertyService = propertyService;
             _browseFilterService = browseFilterService;
             _propDictItemsSearchService = propDictItemsSearchService;
+            _settingsManager = settingsManager;
         }
 
         /// <summary>
@@ -101,6 +106,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
             var browseFilterPropertiesList = new List<AggregationProperty>();
             foreach (var aggregationProperty in browseFilterProperties)
             {
+                aggregationProperty.Size ??= _settingsManager.GetValue(ModuleConstants.Settings.Search.DefaultAggregationSize.Name, 25);
                 browseFilterPropertiesList.Add(aggregationProperty);
                 var catalogProperty = catalogProperties.FirstOrDefault(x => x.Name == aggregationProperty.Name);
                 // If the property is multilanguage, but not dictionary, let's add synthetic aggregation property for each store culture
@@ -109,7 +115,6 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
                     !catalogProperty.Dictionary &&
                     catalogProperty.Multilanguage)
                 {
-                    
                     foreach (var lang in store.Languages)
                     {
                         var aggregationPropertyLangSpecific=aggregationProperty.Clone() as AggregationProperty;

--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogBrowseFiltersController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogBrowseFiltersController.cs
@@ -106,7 +106,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
             var browseFilterPropertiesList = new List<AggregationProperty>();
             foreach (var aggregationProperty in browseFilterProperties)
             {
-                aggregationProperty.Size ??= _settingsManager.GetValue(ModuleConstants.Settings.Search.DefaultAggregationSize.Name, 25);
+                aggregationProperty.Size ??= _settingsManager.GetValue(ModuleConstants.Settings.Search.DefaultAggregationSize.Name, ModuleConstants.DefaultAggregationSize);
                 browseFilterPropertiesList.Add(aggregationProperty);
                 var catalogProperty = catalogProperties.FirstOrDefault(x => x.Name == aggregationProperty.Name);
                 // If the property is multilanguage, but not dictionary, let's add synthetic aggregation property for each store culture

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/en.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/en.VirtoCommerce.Catalog.json
@@ -993,7 +993,8 @@
           "title": "Store serialized catalog objects in the index"
         },
         "DefaultAggregationSize": {
-          "description": "Use this setting to store the default value for Aggregation size in Filtering properties",
+          "description": "Used for aggregations whose size is not set in store aggregation properties. Set to 0 for unlimited size.",
+
           "title": "Default value for aggregation size"
         },
         "EventBasedIndexation": {

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/en.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/en.VirtoCommerce.Catalog.json
@@ -992,6 +992,10 @@
           "description": "Store serialized catalog objects in the index and return them in search results",
           "title": "Store serialized catalog objects in the index"
         },
+        "DefaultAggregationSize": {
+          "description": "Use this setting to store the default value for Aggregation size in Filtering properties",
+          "title": "Default value for aggregation size"
+        },
         "EventBasedIndexation": {
           "Enable": {
             "title": "Enable event-based indexing for catalog entities",

--- a/src/VirtoCommerce.CatalogModule.Web/Model/AggregationProperty.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Model/AggregationProperty.cs
@@ -10,7 +10,7 @@ namespace VirtoCommerce.CatalogModule.Web.Model
         public bool IsSelected { get; set; }
         public string Type { get; set; }
         public string Currency { get; set; }
-        public int? Size { get; set; } = 10;
+        public int? Size { get; set; }
         public int ValuesCount => Values?.Count ?? 0;
         public IList<string> Values { get; set; }
 

--- a/src/VirtoCommerce.CatalogModule.Web/Model/AggregationProperty.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Model/AggregationProperty.cs
@@ -10,7 +10,7 @@ namespace VirtoCommerce.CatalogModule.Web.Model
         public bool IsSelected { get; set; }
         public string Type { get; set; }
         public string Currency { get; set; }
-        public int? Size { get; set; }
+        public int? Size { get; set; } = 10;
         public int ValuesCount => Values?.Count ?? 0;
         public IList<string> Values { get; set; }
 


### PR DESCRIPTION
## Description
Implementation a new setting for Aggregation Size default value. The default value will apply to Size field when the user adds a new property in "Filtering properties" blade.

## References
### QA-test:
### Jira-link:




https://virtocommerce.atlassian.net/browse/PT-6005

### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.225.0-pr-618.zip
