### PR TITLE
PT-8971: Fix broken price range for new aggregation properties

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/aggregation-properties-details.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/aggregation-properties-details.js
@@ -14,10 +14,13 @@ angular.module('virtoCommerce.catalogModule')
             blade.originalProperty = blade.property;
             blade.property = angular.copy(blade.property);
 
+            if (blade.property.values == null)
+                blade.property.values = [];
             blade.values = [];
 
             aggregationProperties.getValues({ storeId: blade.storeId, propertyName: blade.originalProperty.name }, function (results) {
                 blade.values = results;
+                
                 blade.isLoading = false;
             }, function (error) {
                 bladeNavigationService.setError('Error: ' + error.status, blade);
@@ -66,6 +69,7 @@ angular.module('virtoCommerce.catalogModule')
         };
 
         $scope.saveChanges = function () {
+            blade.property.valuesCount = blade.property.values.length;
             angular.copy(blade.property, blade.originalProperty);
             $scope.bladeClose();
         };


### PR DESCRIPTION
## Description
Fix broken price range for new aggregation properties, when open Aggregation properties, add Price ranage, Ex: USD property to facet, click on pencil, try to add any value in range facet.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-8971
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.235.0-pr-627.zip
