### PR TITLE
PT-9260 & PT-9267: Fix catalog bulk update functionality

### DIFF
--- a/src/VirtoCommerce.CatalogModule.BulkActions/DataSources/BaseDataSource.cs
+++ b/src/VirtoCommerce.CatalogModule.BulkActions/DataSources/BaseDataSource.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.CatalogModule.BulkActions.DataSources
     {
         private readonly DataQuery _dataQuery;
 
-        private readonly IListEntrySearchService _listEntrySearchService;
+        private readonly IInternalListEntrySearchService _internalListEntrySearchService;
 
         private readonly int _pageSize = 50;
 
@@ -31,9 +31,9 @@ namespace VirtoCommerce.CatalogModule.BulkActions.DataSources
         /// <param name="dataQuery">
         /// The data query.
         /// </param>
-        public BaseDataSource(IListEntrySearchService listEntrySearchService, DataQuery dataQuery)
+        public BaseDataSource(IInternalListEntrySearchService internalListEntrySearchService, DataQuery dataQuery)
         {
-            _listEntrySearchService = listEntrySearchService;
+            _internalListEntrySearchService = internalListEntrySearchService;
             _dataQuery = dataQuery ?? throw new ArgumentNullException(nameof(dataQuery));
         }
 
@@ -50,7 +50,7 @@ namespace VirtoCommerce.CatalogModule.BulkActions.DataSources
                 else
                 {
                     var searchCriteria = BuildSearchCriteria(_dataQuery);
-                    var searchResult = await _listEntrySearchService.SearchAsync(searchCriteria);
+                    var searchResult = await _internalListEntrySearchService.InnerListEntrySearchAsync(searchCriteria);
                     Items = searchResult.ListEntries;
                 }
             }
@@ -82,7 +82,7 @@ namespace VirtoCommerce.CatalogModule.BulkActions.DataSources
                     var searchCriteria = BuildSearchCriteria(_dataQuery);
                     searchCriteria.Skip = 0;
                     searchCriteria.Take = 0;
-                    var searchResult = await _listEntrySearchService.SearchAsync(searchCriteria);
+                    var searchResult = await _internalListEntrySearchService.InnerListEntrySearchAsync(searchCriteria);
                     result = searchResult.TotalCount;
                 }
             }

--- a/src/VirtoCommerce.CatalogModule.BulkActions/DataSources/DataSourceFactory.cs
+++ b/src/VirtoCommerce.CatalogModule.BulkActions/DataSources/DataSourceFactory.cs
@@ -3,12 +3,13 @@ using VirtoCommerce.BulkActionsModule.Core.Models.BulkActions;
 using VirtoCommerce.BulkActionsModule.Core.Services;
 using VirtoCommerce.CatalogModule.BulkActions.Models;
 using VirtoCommerce.CatalogModule.Core.Search;
+using VirtoCommerce.CatalogModule.Data.Services;
 
 namespace VirtoCommerce.CatalogModule.BulkActions.DataSources
 {
     public class DataSourceFactory : IDataSourceFactory
     {
-        private readonly IListEntrySearchService _listEntrySearchService;
+        private readonly IInternalListEntrySearchService _internalListEntrySearchService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataSourceFactory"/> class.
@@ -16,9 +17,9 @@ namespace VirtoCommerce.CatalogModule.BulkActions.DataSources
         /// <param name="listEntrySearchService">
         /// The search service.
         /// </param>
-        public DataSourceFactory(IListEntrySearchService listEntrySearchService)
+        public DataSourceFactory(IInternalListEntrySearchService internalListEntrySearchService)
         {
-            _listEntrySearchService = listEntrySearchService;
+            _internalListEntrySearchService = internalListEntrySearchService;
         }
 
         public IDataSource Create(BulkActionContext context)
@@ -28,11 +29,11 @@ namespace VirtoCommerce.CatalogModule.BulkActions.DataSources
             switch (context)
             {
                 case CategoryChangeBulkActionContext categoryChangeContext:
-                    result = new BaseDataSource(_listEntrySearchService, categoryChangeContext.DataQuery);
+                    result = new BaseDataSource(_internalListEntrySearchService, categoryChangeContext.DataQuery);
                     break;
 
                 case PropertiesUpdateBulkActionContext propertiesUpdateContext:
-                    result = new ProductDataSource(_listEntrySearchService, propertiesUpdateContext.DataQuery);
+                    result = new ProductDataSource(_internalListEntrySearchService, propertiesUpdateContext.DataQuery);
                     break;
             }
 

--- a/src/VirtoCommerce.CatalogModule.BulkActions/DataSources/ProductDataSource.cs
+++ b/src/VirtoCommerce.CatalogModule.BulkActions/DataSources/ProductDataSource.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.CatalogModule.BulkActions.DataSources
 {
     public class ProductDataSource : BaseDataSource
     {
-        private readonly IListEntrySearchService _listEntrySearchService;
+        private readonly IInternalListEntrySearchService _internalListEntrySearchService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProductDataSource"/> class.
@@ -24,10 +24,10 @@ namespace VirtoCommerce.CatalogModule.BulkActions.DataSources
         /// <param name="dataQuery">
         /// The data query.
         /// </param>
-        public ProductDataSource(IListEntrySearchService listEntrySearchService, DataQuery dataQuery)
-            : base(listEntrySearchService, dataQuery)
+        public ProductDataSource(IInternalListEntrySearchService internalListEntrySearchService, DataQuery dataQuery)
+            : base(internalListEntrySearchService, dataQuery)
         {
-            _listEntrySearchService = listEntrySearchService;
+            _internalListEntrySearchService = internalListEntrySearchService;
         }
 
         protected override CatalogListEntrySearchCriteria BuildSearchCriteria(DataQuery dataQuery)
@@ -110,7 +110,7 @@ namespace VirtoCommerce.CatalogModule.BulkActions.DataSources
             searchCriteria.SearchInChildren = true;
             searchCriteria.SearchInVariations = true;
 
-            var result = await _listEntrySearchService.SearchAsync(searchCriteria);
+            var result = await _internalListEntrySearchService.InnerListEntrySearchAsync(searchCriteria);
             return result;
         }
     }

--- a/src/VirtoCommerce.CatalogModule.BulkActions/Services/BulkPropertyUpdateManager.cs
+++ b/src/VirtoCommerce.CatalogModule.BulkActions/Services/BulkPropertyUpdateManager.cs
@@ -150,7 +150,7 @@ namespace VirtoCommerce.CatalogModule.BulkActions.Services
         private static Func<CatalogProduct, IEnumerable<Property>> CollectionSelector()
         {
             return product =>
-                product.Properties.Where(property => property.IsInherited && property.Type != PropertyType.Category);
+                product.Properties.Where(property => property.Id != null && property.IsInherited && property.Type != PropertyType.Category);
         }
 
         private static bool TrySetCustomProperty(IHasProperties product, Property property)

--- a/tests/VirtoCommerce.CatalogModule.Tests/BaseDataSourceTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/BaseDataSourceTests.cs
@@ -22,7 +22,7 @@ namespace VirtoCommerce.CatalogModule.Tests
             // arrange
             var entries = new List<ListEntryBase> { new ListEntryBase() };
             var dataQuery = Mock.Of<DataQuery>(t => t.ListEntries == entries.ToArray());
-            var searchService = Mock.Of<IListEntrySearchService>();
+            var searchService = Mock.Of<IInternalListEntrySearchService>();
             var dataSource = new BaseDataSource(searchService, dataQuery);
 
             // act
@@ -38,15 +38,15 @@ namespace VirtoCommerce.CatalogModule.Tests
             // arrange
             var listEntrySearchResult = Mock.Of<ListEntrySearchResult>();
             var dataQuery = Mock.Of<DataQuery>(t => t.SearchCriteria == Mock.Of<CatalogListEntrySearchCriteria>());
-            var searchService = new Mock<IListEntrySearchService>();
-            searchService.Setup(t => t.SearchAsync(It.IsAny<CatalogListEntrySearchCriteria>())).ReturnsAsync(listEntrySearchResult);
+            var searchService = new Mock<IInternalListEntrySearchService>();
+            searchService.Setup(t => t.InnerListEntrySearchAsync(It.IsAny<CatalogListEntrySearchCriteria>())).ReturnsAsync(listEntrySearchResult);
             var dataSource = new BaseDataSource(searchService.Object, dataQuery);
 
             // act
             await dataSource.FetchAsync();
 
             // assert
-            searchService.Verify(t => t.SearchAsync(It.IsAny<CatalogListEntrySearchCriteria>()));
+            searchService.Verify(t => t.InnerListEntrySearchAsync(It.IsAny<CatalogListEntrySearchCriteria>()));
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace VirtoCommerce.CatalogModule.Tests
             // arrange
             var entries = new List<ListEntryBase> { new ListEntryBase() };
             var dataQuery = Mock.Of<DataQuery>(t => t.ListEntries == entries.ToArray());
-            var searchService = Mock.Of<IListEntrySearchService>();
+            var searchService = Mock.Of<IInternalListEntrySearchService>();
             var dataSource = new BaseDataSource(searchService, dataQuery);
 
             // act
@@ -70,7 +70,7 @@ namespace VirtoCommerce.CatalogModule.Tests
         {
             // arrange
             var dataQuery = Mock.Of<DataQuery>();
-            var searchService = Mock.Of<IListEntrySearchService>();
+            var searchService = Mock.Of<IInternalListEntrySearchService>();
             var dataSource = new BaseDataSource(searchService, dataQuery);
 
             // act
@@ -86,7 +86,7 @@ namespace VirtoCommerce.CatalogModule.Tests
         {
             // arrange
             var dataQuery = Mock.Of<DataQuery>();
-            var searchService = Mock.Of<IListEntrySearchService>();
+            var searchService = Mock.Of<IInternalListEntrySearchService>();
             var dataSource = new BaseDataSource(searchService, dataQuery);
 
             // act
@@ -102,9 +102,9 @@ namespace VirtoCommerce.CatalogModule.Tests
         {
             // arrange
             var dataQuery = Mock.Of<DataQuery>(t => t.SearchCriteria == new CatalogListEntrySearchCriteria());
-            var searchService = new Mock<IListEntrySearchService>();
+            var searchService = new Mock<IInternalListEntrySearchService>();
             var listEntrySearchResult = new ListEntrySearchResult { TotalCount = 1 };
-            searchService.Setup(t => t.SearchAsync(It.IsAny<CatalogListEntrySearchCriteria>())).ReturnsAsync(listEntrySearchResult);
+            searchService.Setup(t => t.InnerListEntrySearchAsync(It.IsAny<CatalogListEntrySearchCriteria>())).ReturnsAsync(listEntrySearchResult);
 
             var dataSource = new BaseDataSource(searchService.Object, dataQuery);
 
@@ -121,7 +121,7 @@ namespace VirtoCommerce.CatalogModule.Tests
         {
             // arrange
             var dataQuery = Mock.Of<DataQuery>(t => t.ListEntries == new[] { new ListEntryBase() });
-            var searchService = new Mock<IListEntrySearchService>();
+            var searchService = new Mock<IInternalListEntrySearchService>();
 
             var dataSource = new BaseDataSource(searchService.Object, dataQuery);
 

--- a/tests/VirtoCommerce.CatalogModule.Tests/ClassCtorTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/ClassCtorTests.cs
@@ -36,7 +36,7 @@ namespace VirtoCommerce.CatalogModule.Tests
             var action = new Action(
                 () =>
                 {
-                    new BaseDataSource(Mock.Of<IListEntrySearchService>(), null);
+                    new BaseDataSource(Mock.Of<IInternalListEntrySearchService>(), null);
                 });
 
             // assert

--- a/tests/VirtoCommerce.CatalogModule.Tests/DataSourceFactoryTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/DataSourceFactoryTests.cs
@@ -61,7 +61,7 @@ namespace VirtoCommerce.CatalogModule.Tests
 
         private IDataSourceFactory BuildDataSourceFactory()
         {
-            var searchService = new Mock<IListEntrySearchService>();
+            var searchService = new Mock<IInternalListEntrySearchService>();
             return new DataSourceFactory(searchService.Object);
         }
     }


### PR DESCRIPTION
use IInternalListEntrySearchService instead IListEntrySearchService
remove parent properties for variation product

## Description

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-9260
https://virtocommerce.atlassian.net/browse/PT-9267

### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.243.0-pr-637-e888.zip
