### PR TITLE
PT-96510: Fixs Display incorrect date in Created, Modified date for catalog

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Model/CatalogEntity.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Model/CatalogEntity.cs
@@ -48,6 +48,12 @@ namespace VirtoCommerce.CatalogModule.Data.Model
                 throw new ArgumentNullException(nameof(catalog));
 
             catalog.Id = Id;
+
+            catalog.CreatedDate = CreatedDate;
+            catalog.ModifiedDate = ModifiedDate;
+            catalog.CreatedBy = CreatedBy;
+            catalog.ModifiedBy = ModifiedBy;
+
             catalog.Name = Name;
             catalog.IsVirtual = Virtual;
             catalog.OuterId = OuterId;
@@ -92,6 +98,12 @@ namespace VirtoCommerce.CatalogModule.Data.Model
             pkMap.AddPair(catalog, this);
 
             Id = catalog.Id;
+
+            CreatedDate = catalog.CreatedDate;
+            ModifiedDate = catalog.ModifiedDate;
+            CreatedBy = catalog.CreatedBy;
+            ModifiedBy = catalog.ModifiedBy;
+
             Name = catalog.Name;
             Virtual = catalog.IsVirtual;
             OuterId = catalog.OuterId;


### PR DESCRIPTION
## Description
fix: Display incorrect date in Created, Modified date for catalog

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-9510
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.242.0-pr-638-dd25.zip
