### PR TITLE
PT-10174:  Deleting a linked category from roots

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/categories-items-list.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/categories-items-list.js
@@ -188,7 +188,7 @@ angular.module('virtoCommerce.catalogModule')
 
                     if (listItem.type === 'category') {
                         if (blade.catalog && blade.catalog.isVirtual
-                            && _.some(listItem.links, function (x) { return x.categoryId === blade.categoryId; })) {
+                            && _.some(listItem.links, function (x) { return x.categoryId === blade.categoryId || x.categoryId === null && !blade.categoryId; })) {
                             deletingLink = true;
                         } else {
                             categoryIds.push(listItem.id);

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/categories-items-list.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/categories-items-list.js
@@ -188,7 +188,10 @@ angular.module('virtoCommerce.catalogModule')
 
                     if (listItem.type === 'category') {
                         if (blade.catalog && blade.catalog.isVirtual
-                            && _.some(listItem.links, function (x) { return x.categoryId === blade.categoryId || x.categoryId === null && !blade.categoryId; })) {
+                            && _.some(listItem.links, function (x) {
+                                return x.categoryId === blade.categoryId
+                                    || !x.categoryId && !blade.categoryId;
+                            })) {
                             deletingLink = true;
                         } else {
                             categoryIds.push(listItem.id);


### PR DESCRIPTION
## Description
fix:  Deleting a linked category from roots deletes it completely from DB instead of remove link.

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/PT-10174
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.252.0-pr-651-09a2.zip
