### PR TITLE
PT-10245: Properties being emptied on products - Linking and Saving

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Model/ItemEntity.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Model/ItemEntity.cs
@@ -288,7 +288,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
                 var propValues = new List<PropertyValue>();
                 var forceSavePropertyValues = false;
 
-                foreach (var property in product.Properties.Where(x => x.Type == PropertyType.Product || x.Type == PropertyType.Variation ))
+                foreach (var property in product.Properties.Where(x => x.Type == PropertyType.Product || x.Type == PropertyType.Variation))
                 {
                     if (property.Values != null)
                     {

--- a/src/VirtoCommerce.CatalogModule.Data/Model/ItemEntity.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Model/ItemEntity.cs
@@ -288,7 +288,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
                 var propValues = new List<PropertyValue>();
                 var forceSavePropertyValues = false;
 
-                foreach (var property in product.Properties.Where(x => x.Type == PropertyType.Product || x.Type == PropertyType.Variation))
+                foreach (var property in product.Properties.Where(x => !x.IsInherited && (x.Type == PropertyType.Product || x.Type == PropertyType.Variation) ))
                 {
                     if (property.Values != null)
                     {

--- a/src/VirtoCommerce.CatalogModule.Data/Model/ItemEntity.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Model/ItemEntity.cs
@@ -288,7 +288,7 @@ namespace VirtoCommerce.CatalogModule.Data.Model
                 var propValues = new List<PropertyValue>();
                 var forceSavePropertyValues = false;
 
-                foreach (var property in product.Properties.Where(x => !x.IsInherited && (x.Type == PropertyType.Product || x.Type == PropertyType.Variation) ))
+                foreach (var property in product.Properties.Where(x => x.Type == PropertyType.Product || x.Type == PropertyType.Variation ))
                 {
                     if (property.Values != null)
                     {

--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
@@ -307,7 +307,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
         private async Task<IList<T>> LoadCatalogEntriesAsync<T>(string[] ids)
         {
 #pragma warning disable CS0618 // Variations can be used here
-            var products = await _itemService.GetByIdsAsync(ids, (ItemResponseGroup.Links | ItemResponseGroup.Variations).ToString());
+            var products = await _itemService.GetByIdsAsync(ids, (ItemResponseGroup.Links | ItemResponseGroup.ItemProperties | ItemResponseGroup.Variations).ToString());
 #pragma warning restore CS0618
             var categories = await _categoryService.GetAsync(ids.Except(products.Select(x => x.Id)).ToList(), CategoryResponseGroup.WithLinks.ToString());
             return products.OfType<T>().Concat(categories.OfType<T>()).ToList();

--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
@@ -309,7 +309,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
 #pragma warning disable CS0618 // Variations can be used here
             var products = await _itemService.GetByIdsAsync(ids, (ItemResponseGroup.Links | ItemResponseGroup.ItemProperties | ItemResponseGroup.Variations).ToString());
 #pragma warning restore CS0618
-            var categories = await _categoryService.GetAsync(ids.Except(products.Select(x => x.Id)).ToList(), CategoryResponseGroup.WithLinks.ToString());
+            var categories = await _categoryService.GetAsync(ids.Except(products.Select(x => x.Id)).ToList(), (CategoryResponseGroup.WithLinks | CategoryResponseGroup.WithProperties).ToString());
             return products.OfType<T>().Concat(categories.OfType<T>()).ToList();
         }
     }

--- a/tests/VirtoCommerce.CatalogModule.Tests/VirtoCommerce.CatalogModule.Tests.csproj
+++ b/tests/VirtoCommerce.CatalogModule.Tests/VirtoCommerce.CatalogModule.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
fix: Properties being emptied on products - Linking and Savin

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/PT-10245
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.252.0-pr-652-ffbf.zip
