### PR TITLE
PT-11173: Make index IX_Code_CatalogId unique on SQL Server

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data.SqlServer/Migrations/20230316134918_FixItemCodeIndex.Designer.cs
+++ b/src/VirtoCommerce.CatalogModule.Data.SqlServer/Migrations/20230316134918_FixItemCodeIndex.Designer.cs
@@ -3,17 +3,19 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.CatalogModule.Data.Repositories;
 
 #nullable disable
 
-namespace VirtoCommerce.CatalogModule.Data.Migrations
+namespace VirtoCommerce.CatalogModule.Data.SqlServer.Migrations
 {
     [DbContext(typeof(CatalogDbContext))]
-    partial class CatalogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230316134918_FixItemCodeIndex")]
+    partial class FixItemCodeIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.CatalogModule.Data.SqlServer/Migrations/20230316134918_FixItemCodeIndex.cs
+++ b/src/VirtoCommerce.CatalogModule.Data.SqlServer/Migrations/20230316134918_FixItemCodeIndex.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.CatalogModule.Data.SqlServer.Migrations
+{
+    public partial class FixItemCodeIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Code_CatalogId",
+                table: "Item");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Category_Parent_category_check",
+                table: "Category");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Code_CatalogId",
+                table: "Item",
+                columns: new[] { "Code", "CatalogId" },
+                unique: true);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Category_Parent_category_check",
+                table: "Category",
+                sql: "\"ParentCategoryId\" != \"Id\"");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Code_CatalogId",
+                table: "Item");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Category_Parent_category_check",
+                table: "Category");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Code_CatalogId",
+                table: "Item",
+                columns: new[] { "Code", "CatalogId" });
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Category_Parent_category_check",
+                table: "Category",
+                sql: "ParentCategoryId != Id");
+        }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.CatalogModule.Data.SqlServer/Readme.md
@@ -6,7 +6,6 @@ Add-Migration Initial -Context VirtoCommerce.CatalogModule.Data.Repositories.Cat
 
 ### Entity Framework Core Commands
 ```
-
 dotnet tool install --global dotnet-ef --version 6.*
 ```
 


### PR DESCRIPTION
## Description
This PR fixes a bug introduced by https://github.com/VirtoCommerce/vc-module-catalog/pull/455
MySQL and PostgreSQL migrations were correct.

**IMPORTANT**
Before installing this update you should find and fix all duplicates, otherwise platform will not start.
```sql
select CatalogId, Code, count(Id)
from Item
group by CatalogId, Code
having count(Id) > 1
```
## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/PT-11173
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.261.0-pr-667-519f.zip
