### PR TITLE
PT-12168: Reduce memory consumption when indexing products and categories

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/Search/IProductSearchService.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Search/IProductSearchService.cs
@@ -10,5 +10,10 @@ namespace VirtoCommerce.CatalogModule.Core.Search
     {
         [Obsolete("Use SearchAsync()")]
         Task<ProductSearchResult> SearchProductsAsync(ProductSearchCriteria criteria);
+
+        /// <summary>
+        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// </summary>
+        Task<ProductSearchResult> SearchNoCloneAsync(ProductSearchCriteria criteria);
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Core/Search/IProductSearchService.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Search/IProductSearchService.cs
@@ -12,7 +12,7 @@ namespace VirtoCommerce.CatalogModule.Core.Search
         Task<ProductSearchResult> SearchProductsAsync(ProductSearchCriteria criteria);
 
         /// <summary>
-        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// Returns data from the cache without cloning. This consumes less memory, but returned data must not be modified.
         /// </summary>
         Task<ProductSearchResult> SearchNoCloneAsync(ProductSearchCriteria criteria);
     }

--- a/src/VirtoCommerce.CatalogModule.Core/Services/ICatalogService.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Services/ICatalogService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.Platform.Core.GenericCrud;
@@ -9,5 +10,10 @@ namespace VirtoCommerce.CatalogModule.Core.Services
         Task<Catalog[]> GetByIdsAsync(string[] catalogIds, string responseGroup = null);
         Task SaveChangesAsync(Catalog[] catalogs);
         Task DeleteAsync(string[] catalogIds);
+
+        /// <summary>
+        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// </summary>
+        Task<IList<Catalog>> GetNoCloneAsync(IList<string> ids, string responseGroup = null);
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Core/Services/ICatalogService.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Services/ICatalogService.cs
@@ -12,7 +12,7 @@ namespace VirtoCommerce.CatalogModule.Core.Services
         Task DeleteAsync(string[] catalogIds);
 
         /// <summary>
-        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// Returns data from the cache without cloning. This consumes less memory, but returned data must not be modified.
         /// </summary>
         Task<IList<Catalog>> GetNoCloneAsync(IList<string> ids, string responseGroup = null);
     }

--- a/src/VirtoCommerce.CatalogModule.Core/Services/ICategoryService.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Services/ICategoryService.cs
@@ -12,7 +12,7 @@ namespace VirtoCommerce.CatalogModule.Core.Services
         Task DeleteAsync(string[] categoryIds);
 
         /// <summary>
-        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// Returns data from the cache without cloning. This consumes less memory, but returned data must not be modified.
         /// </summary>
         Task<IList<Category>> GetNoCloneAsync(IList<string> ids, string responseGroup = null);
     }

--- a/src/VirtoCommerce.CatalogModule.Core/Services/ICategoryService.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Services/ICategoryService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.Platform.Core.GenericCrud;
@@ -9,5 +10,10 @@ namespace VirtoCommerce.CatalogModule.Core.Services
         Task<Category[]> GetByIdsAsync(string[] categoryIds, string responseGroup, string catalogId = null);
         Task SaveChangesAsync(Category[] categories);
         Task DeleteAsync(string[] categoryIds);
+
+        /// <summary>
+        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// </summary>
+        Task<IList<Category>> GetNoCloneAsync(IList<string> ids, string responseGroup = null);
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Core/Services/IItemService.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Services/IItemService.cs
@@ -13,5 +13,10 @@ namespace VirtoCommerce.CatalogModule.Core.Services
         Task<CatalogProduct> GetByIdAsync(string itemId, string responseGroup, string catalogId = null);
         Task SaveChangesAsync(CatalogProduct[] items);
         Task DeleteAsync(string[] itemIds);
+
+        /// <summary>
+        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// </summary>
+        Task<IList<CatalogProduct>> GetNoCloneAsync(IList<string> ids, string responseGroup);
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Core/Services/IItemService.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Services/IItemService.cs
@@ -15,7 +15,7 @@ namespace VirtoCommerce.CatalogModule.Core.Services
         Task DeleteAsync(string[] itemIds);
 
         /// <summary>
-        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// Returns data from the cache without cloning. This consumes less memory, but returned data must not be modified.
         /// </summary>
         Task<IList<CatalogProduct>> GetNoCloneAsync(IList<string> ids, string responseGroup);
     }

--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/CategoryDocumentBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/CategoryDocumentBuilder.cs
@@ -36,7 +36,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
         protected virtual async Task<Category[]> GetCategories(IList<string> categoryIds)
         {
             var responseGroup = CategoryResponseGroup.WithProperties | CategoryResponseGroup.WithOutlines | CategoryResponseGroup.WithImages | CategoryResponseGroup.WithSeo | CategoryResponseGroup.WithLinks | CategoryResponseGroup.WithDescriptions;
-            var categories = await _categoryService.GetAsync(categoryIds.ToList(), responseGroup.ToString());
+            var categories = await _categoryService.GetNoCloneAsync(categoryIds.ToList(), responseGroup.ToString());
 
             return categories.ToArray();
         }

--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductDocumentBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductDocumentBuilder.cs
@@ -49,7 +49,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
                     do
                     {
                         variationsSearchCriteria.Skip = skipCount;
-                        var productVariations = await _productsSearchService.SearchAsync(variationsSearchCriteria);
+                        var productVariations = await _productsSearchService.SearchNoCloneAsync(variationsSearchCriteria);
                         foreach (var variation in productVariations.Results)
                         {
                             result.Add(CreateDocument(variation));
@@ -72,7 +72,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
         protected virtual async Task<CatalogProduct[]> GetProducts(IList<string> productIds)
         {
 #pragma warning disable CS0618 // Variations can be used here
-            var products = await _itemService.GetAsync(productIds.ToList(), (ItemResponseGroup.Full & ~ItemResponseGroup.Variations).ToString());
+            var products = await _itemService.GetNoCloneAsync(productIds.ToList(), (ItemResponseGroup.Full & ~ItemResponseGroup.Variations).ToString());
 #pragma warning restore CS0618
 
             return products.ToArray();

--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductDocumentBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductDocumentBuilder.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Model.Search;
 using VirtoCommerce.CatalogModule.Core.Search;
 using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.CatalogModule.Data.Caching;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.SearchModule.Core.Extenstions;
 using VirtoCommerce.SearchModule.Core.Model;
@@ -37,13 +39,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
                 //Index product variants by separate chunked requests for performance reason
                 if (product.MainProductId == null)
                 {
-                    const int pageSize = 50;
-                    var variationsSearchCriteria = new Core.Model.Search.ProductSearchCriteria
-                    {
-                        Take = pageSize,
-                        MainProductId = product.Id,
-                        ResponseGroup = (ItemResponseGroup.ItemInfo | ItemResponseGroup.Properties | ItemResponseGroup.Seo | ItemResponseGroup.Outlines | ItemResponseGroup.ItemAssets).ToString()
-                    };
+                    var variationsSearchCriteria = GetVariationSearchCriteria(product);
                     var skipCount = 0;
                     int totalCount;
                     do
@@ -52,11 +48,11 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
                         var productVariations = await _productsSearchService.SearchNoCloneAsync(variationsSearchCriteria);
                         foreach (var variation in productVariations.Results)
                         {
-                            result.Add(CreateDocument(variation));
+                            result.Add(CreateDocument(variation, product));
                             IndexProductVariation(doc, variation);
                         }
                         totalCount = productVariations.TotalCount;
-                        skipCount += pageSize;
+                        skipCount += variationsSearchCriteria.Take;
                     }
                     while (skipCount < totalCount);
                 }
@@ -76,6 +72,25 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
 #pragma warning restore CS0618
 
             return products.ToArray();
+        }
+
+        protected virtual ProductSearchCriteria GetVariationSearchCriteria(CatalogProduct product)
+        {
+            var criteria = AbstractTypeFactory<ProductSearchCriteria>.TryCreateInstance();
+
+            criteria.MainProductId = product.Id;
+            criteria.ResponseGroup = (ItemResponseGroup.ItemInfo | ItemResponseGroup.Properties | ItemResponseGroup.Seo | ItemResponseGroup.Outlines | ItemResponseGroup.ItemAssets).ToString();
+            criteria.Take = 50;
+
+            return criteria;
+        }
+
+        /// <summary>
+        /// The mainProduct argument contains more information than variation.MainProduct
+        /// </summary>
+        protected virtual IndexDocument CreateDocument(CatalogProduct variation, CatalogProduct mainProduct)
+        {
+            return CreateDocument(variation);
         }
 
         protected virtual IndexDocument CreateDocument(CatalogProduct product)

--- a/src/VirtoCommerce.CatalogModule.Data/Search/ProductSearchService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/ProductSearchService.cs
@@ -40,7 +40,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search
         }
 
         /// <summary>
-        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// Returns data from the cache without cloning. This consumes less memory, but returned data must not be modified.
         /// </summary>
         public Task<ProductSearchResult> SearchNoCloneAsync(ProductSearchCriteria criteria)
         {

--- a/src/VirtoCommerce.CatalogModule.Data/Search/ProductSearchService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/ProductSearchService.cs
@@ -36,7 +36,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search
 
         public override Task<ProductSearchResult> SearchAsync(ProductSearchCriteria criteria)
         {
-            return InternalSearchNoCloneAsync(criteria, clone: true);
+            return InternalSearchAsync(criteria, clone: true);
         }
 
         /// <summary>
@@ -44,13 +44,13 @@ namespace VirtoCommerce.CatalogModule.Data.Search
         /// </summary>
         public Task<ProductSearchResult> SearchNoCloneAsync(ProductSearchCriteria criteria)
         {
-            return InternalSearchNoCloneAsync(criteria, clone: false);
+            return InternalSearchAsync(criteria, clone: false);
         }
 
 
-        protected virtual async Task<ProductSearchResult> InternalSearchNoCloneAsync(ProductSearchCriteria criteria, bool clone)
+        protected virtual async Task<ProductSearchResult> InternalSearchAsync(ProductSearchCriteria criteria, bool clone)
         {
-            var cacheKey = CacheKey.With(GetType(), nameof(InternalSearchNoCloneAsync), criteria.GetCacheKey());
+            var cacheKey = CacheKey.With(GetType(), nameof(InternalSearchAsync), criteria.GetCacheKey());
 
             var idsResult = await _platformMemoryCache.GetOrCreateExclusiveAsync(cacheKey, async cacheOptions =>
             {

--- a/src/VirtoCommerce.CatalogModule.Data/Services/CatalogService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/CatalogService.cs
@@ -88,7 +88,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
         }
 
         /// <summary>
-        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// Returns data from the cache without cloning. This consumes less memory, but returned data must not be modified.
         /// </summary>
         public virtual Task<IList<Catalog>> GetNoCloneAsync(IList<string> ids, string responseGroup = null)
         {

--- a/src/VirtoCommerce.CatalogModule.Data/Services/CatalogService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/CatalogService.cs
@@ -40,8 +40,6 @@ namespace VirtoCommerce.CatalogModule.Data.Services
             _hasPropertyValidator = hasPropertyValidator;
         }
 
-        #region ICatalogService Members
-
         public virtual async Task<Catalog[]> GetByIdsAsync(string[] catalogIds, string responseGroup = null)
         {
             return (await GetAsync(catalogIds.ToList(), responseGroup)).ToArray();
@@ -55,30 +53,6 @@ namespace VirtoCommerce.CatalogModule.Data.Services
         public virtual Task DeleteAsync(string[] catalogIds)
         {
             return DeleteAsync(catalogIds, softDelete: false);
-        }
-
-        #endregion
-
-        public override async Task<IReadOnlyCollection<Catalog>> GetAsync(List<string> ids, string responseGroup = null)
-        {
-            var result = new List<Catalog>();
-            var catalogsByIds = await PreloadCatalogsAsync();
-
-            foreach (var catalogId in ids.Where(x => x != null))
-            {
-                var catalog = catalogsByIds[catalogId];
-                if (catalog != null)
-                {
-                    catalog = catalog.CloneTyped();
-
-                    // Reduce details according to response group
-                    catalog.ReduceDetails(responseGroup);
-
-                    result.Add(catalog);
-                }
-            }
-
-            return result;
         }
 
         public override async Task DeleteAsync(IEnumerable<string> ids, bool softDelete = false)
@@ -108,6 +82,43 @@ namespace VirtoCommerce.CatalogModule.Data.Services
             }
         }
 
+        public override async Task<IReadOnlyCollection<Catalog>> GetAsync(List<string> ids, string responseGroup = null)
+        {
+            return await InternalGetAsync(ids, responseGroup, clone: true) as IReadOnlyCollection<Catalog>;
+        }
+
+        /// <summary>
+        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// </summary>
+        public virtual Task<IList<Catalog>> GetNoCloneAsync(IList<string> ids, string responseGroup = null)
+        {
+            return InternalGetAsync(ids, responseGroup, clone: false);
+        }
+
+
+        protected virtual async Task<IList<Catalog>> InternalGetAsync(IList<string> ids, string responseGroup, bool clone)
+        {
+            var result = new List<Catalog>();
+            var catalogsByIds = await PreloadCatalogsAsync();
+
+            foreach (var catalogId in ids.Where(x => x != null))
+            {
+                if (catalogsByIds.TryGetValue(catalogId, out var catalog) && catalog != null)
+                {
+                    if (clone)
+                    {
+                        catalog = catalog.CloneTyped();
+
+                        // Reduce details according to response group
+                        catalog.ReduceDetails(responseGroup);
+                    }
+
+                    result.Add(catalog);
+                }
+            }
+
+            return result;
+        }
 
         protected override async Task BeforeSaveChanges(IEnumerable<Catalog> models)
         {

--- a/src/VirtoCommerce.CatalogModule.Data/Services/CategoryService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/CategoryService.cs
@@ -99,6 +99,27 @@ namespace VirtoCommerce.CatalogModule.Data.Services
             return await GetByIdsAsync(ids.ToArray(), responseGroup, catalogId: null);
         }
 
+        /// <summary>
+        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// </summary>
+        public virtual async Task<IList<Category>> GetNoCloneAsync(IList<string> ids, string responseGroup = null)
+        {
+            var result = new List<Category>();
+
+            foreach (var categoryId in ids.Where(x => x != null))
+            {
+                var categoryBranch = await PreloadCategoryBranchAsync(categoryId);
+
+                if (categoryBranch.TryGetValue(categoryId, out var category) && category != null)
+                {
+                    _outlineService.FillOutlinesForObjects(new List<Category> { category }, catalogId: null);
+                    result.Add(category);
+                }
+            }
+
+            return result.ToArray();
+        }
+
         public override async Task DeleteAsync(IEnumerable<string> ids, bool softDelete = false)
         {
             var categoryIds = ids.ToArray();
@@ -206,7 +227,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
             using var repository = _repositoryFactory();
             repository.DisableChangesTracking();
 
-            return await repository.SearchCategoriesHierarchyAsync(categoryId);
+            return (await LoadEntities(repository, new[] { categoryId }, CategoryResponseGroup.Full.ToString())).ToArray();
         }
 
         [Obsolete("Use PreloadCategoriesAsync() instead.")]
@@ -270,7 +291,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
         protected virtual async Task LoadDependencies(ICollection<Category> categories, IDictionary<string, Category> preloadedCategoriesMap)
         {
             var catalogsIds = new { categories }.GetFlatObjectsListWithInterface<IHasCatalogId>().Select(x => x.CatalogId).Where(x => x != null).Distinct().ToList();
-            var catalogsByIdDict = (await _catalogService.GetAsync(catalogsIds)).ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
+            var catalogsByIdDict = (await _catalogService.GetNoCloneAsync(catalogsIds)).ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
 
             foreach (var category in categories)
             {
@@ -281,11 +302,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
                 // Load all parent categories
                 if (category.ParentId != null)
                 {
-                    category.Parents = TreeExtension
-                        .GetAncestors(category, x => x.ParentId != null ? preloadedCategoriesMap[x.ParentId] : null)
-                        .Reverse()
-                        .ToArray();
-
+                    category.Parents = (await GetParentsAsync(category, preloadedCategoriesMap)).ToArray();
                     category.Parent = category.Parents.LastOrDefault();
                 }
 
@@ -296,7 +313,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
                     link.Catalog = catalogsByIdDict.GetValueOrThrow(link.CatalogId, $"link catalog with key {link.CatalogId} doesn't exist");
                     if (link.CategoryId != null)
                     {
-                        link.Category = preloadedCategoriesMap[link.CategoryId];
+                        link.Category = await GetCategoryAsync(link.CategoryId, preloadedCategoriesMap);
                     }
                 }
 
@@ -305,10 +322,42 @@ namespace VirtoCommerce.CatalogModule.Data.Services
                     property.Catalog = property.CatalogId != null ? catalogsByIdDict[property.CatalogId] : null;
                     if (property.CategoryId != null)
                     {
-                        property.Category = preloadedCategoriesMap[property.CategoryId];
+                        property.Category = await GetCategoryAsync(property.CategoryId, preloadedCategoriesMap);
                     }
                 }
             }
+        }
+
+        private async Task<IList<Category>> GetParentsAsync(Category category, IDictionary<string, Category> preloadedCategoriesMap)
+        {
+            var list = new List<Category>();
+
+            for (var parent = await GetCategoryAsync(category.ParentId, preloadedCategoriesMap);
+                 parent != null;
+                 parent = await GetCategoryAsync(parent.ParentId, preloadedCategoriesMap))
+            {
+                list.Insert(0, parent);
+            }
+
+            return list;
+        }
+
+        private async Task<Category> GetCategoryAsync(string id, IDictionary<string, Category> preloadedCategoriesMap)
+        {
+            if (id is null)
+            {
+                return null;
+            }
+
+            if (preloadedCategoriesMap.TryGetValue(id, out var result) && result != null)
+            {
+                return result;
+            }
+
+            result = (await PreloadCategoryBranchAsync(id))[id];
+            preloadedCategoriesMap[id] = result;
+
+            return result;
         }
 
         protected virtual void ApplyInheritanceRules(IEnumerable<Category> categories)

--- a/src/VirtoCommerce.CatalogModule.Data/Services/CategoryService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/CategoryService.cs
@@ -100,7 +100,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
         }
 
         /// <summary>
-        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// Returns data from the cache without cloning. This consumes less memory, but returned data must not be modified.
         /// </summary>
         public virtual async Task<IList<Category>> GetNoCloneAsync(IList<string> ids, string responseGroup = null)
         {

--- a/src/VirtoCommerce.CatalogModule.Data/Services/ItemService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/ItemService.cs
@@ -151,7 +151,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
         }
 
         /// <summary>
-        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// Returns data from the cache without cloning. This consumes less memory, but returned data must not be modified.
         /// </summary>
         public virtual Task<IList<CatalogProduct>> GetNoCloneAsync(IList<string> ids, string responseGroup)
         {

--- a/src/VirtoCommerce.CatalogModule.Data/Services/ItemService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/ItemService.cs
@@ -145,6 +145,40 @@ namespace VirtoCommerce.CatalogModule.Data.Services
             }
         }
 
+        public override async Task<IReadOnlyCollection<CatalogProduct>> GetAsync(List<string> ids, string responseGroup = null)
+        {
+            return await InternalGetAsync(ids, responseGroup, clone: true) as IReadOnlyCollection<CatalogProduct>;
+        }
+
+        /// <summary>
+        /// Returns data from the cache without cloning, which consumes less memory, but returned data must not be modified.
+        /// </summary>
+        public virtual Task<IList<CatalogProduct>> GetNoCloneAsync(IList<string> ids, string responseGroup)
+        {
+            return InternalGetAsync(ids, responseGroup, clone: false);
+        }
+
+
+        protected virtual async Task<IList<CatalogProduct>> InternalGetAsync(IList<string> ids, string responseGroup, bool clone)
+        {
+            var cacheKeyPrefix = CacheKey.With(GetType(), nameof(InternalGetAsync), responseGroup);
+
+            var models = await _platformMemoryCache.GetOrLoadByIdsAsync(cacheKeyPrefix, ids,
+                missingIds => GetByIdsNoCache(missingIds, responseGroup),
+                ConfigureCache);
+
+            if (clone)
+            {
+                return models
+                    .Select(x => x.CloneTyped())
+                    .OrderBy(x => ids.IndexOf(x.Id))
+                    .ToList();
+            }
+
+            return models
+                .OrderBy(x => ids.IndexOf(x.Id))
+                .ToList();
+        }
 
         protected override async Task<IEnumerable<ItemEntity>> LoadEntities(IRepository repository, IEnumerable<string> ids, string responseGroup)
         {
@@ -252,10 +286,10 @@ namespace VirtoCommerce.CatalogModule.Data.Services
         {
             // TODO: Refactor to do this by one call and iteration
             var catalogsIds = new { products }.GetFlatObjectsListWithInterface<IHasCatalogId>().Select(x => x.CatalogId).Where(x => x != null).Distinct().ToList();
-            var catalogsByIdDict = (await _catalogService.GetAsync(catalogsIds)).ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
+            var catalogsByIdDict = (await _catalogService.GetNoCloneAsync(catalogsIds)).ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
 
             var categoriesIds = new { products }.GetFlatObjectsListWithInterface<IHasCategoryId>().Select(x => x.CategoryId).Where(x => x != null).Distinct().ToList();
-            var categoriesByIdDict = (await _categoryService.GetAsync(categoriesIds, CategoryResponseGroup.Full.ToString())).ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
+            var categoriesByIdDict = (await _categoryService.GetNoCloneAsync(categoriesIds)).ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
 
             var allImages = new { products }.GetFlatObjectsListWithInterface<IHasImages>().Where(x => x.Images != null).SelectMany(x => x.Images);
             foreach (var image in allImages.Where(x => !string.IsNullOrEmpty(x.Url)))
@@ -310,9 +344,7 @@ namespace VirtoCommerce.CatalogModule.Data.Services
 
                 if (!string.IsNullOrEmpty(link.CategoryId))
                 {
-                    link.Category = categoriesByIdDict.GetValueOrThrow(link.CategoryId, $"link category with key {link.CategoryId} doesn't exist").Clone() as Category;
-                    var necessaryGroups = CategoryResponseGroup.WithProperties | CategoryResponseGroup.WithParents | CategoryResponseGroup.WithSeo;
-                    link.Category?.ReduceDetails(necessaryGroups.ToString());
+                    link.Category = categoriesByIdDict.GetValueOrThrow(link.CategoryId, $"link category with key {link.CategoryId} doesn't exist");
                 }
             }
         }

--- a/tests/VirtoCommerce.CatalogModule.Tests/CategoryInheritanceTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/CategoryInheritanceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentValidation;
@@ -104,10 +105,13 @@ namespace VirtoCommerce.CatalogModule.Tests
             };
 
             var categoriesBranchResult = new List<CategoryEntity> { rootCategory, level1Category, level2Category };
-            _repositoryMock.Setup(x => x.SearchCategoriesHierarchyAsync(level2Category.Id))
-                .ReturnsAsync(categoriesBranchResult);
 
-            _catalogServiceMock.Setup(t => t.GetAsync(new List<string> { catalog.Id }, It.IsAny<string>()))
+            _repositoryMock
+                .Setup(x => x.GetCategoriesByIdsAsync(It.IsAny<string[]>(), It.IsAny<string>()))
+                .ReturnsAsync((string[] ids, string _) => categoriesBranchResult.Where(x => ids.Contains(x.Id)).ToArray());
+
+            _catalogServiceMock
+                .Setup(t => t.GetNoCloneAsync(new[] { catalog.Id }, It.IsAny<string>()))
                 .ReturnsAsync(new[] { catalog });
 
             // Act

--- a/tests/VirtoCommerce.CatalogModule.Tests/ItemServiceUnitTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/ItemServiceUnitTests.cs
@@ -70,8 +70,13 @@ namespace VirtoCommerce.CatalogModule.Tests
                         .ReturnsAsync(new[] { newItemEntity });
                 });
 
-            _catalogServiceMock.Setup(x => x.GetAsync(It.IsAny<List<string>>(), default)).ReturnsAsync(new Catalog[] { new Catalog() { Id = newItem.CatalogId } });
-            _categoryServiceMock.Setup(x => x.GetAsync(It.IsAny<List<string>>(), It.IsAny<string>())).ReturnsAsync(new Category[] { new Category() { Id = newItem.CategoryId } });
+            _catalogServiceMock
+                .Setup(x => x.GetNoCloneAsync(It.IsAny<IList<string>>(), It.IsAny<string>()))
+                .ReturnsAsync(new[] { new Catalog { Id = newItem.CatalogId } });
+
+            _categoryServiceMock
+                .Setup(x => x.GetNoCloneAsync(It.IsAny<IList<string>>(), It.IsAny<string>()))
+                .ReturnsAsync(new[] { new Category { Id = newItem.CategoryId } });
 
             //Act
             var nullItem = await service.GetByIdAsync(id, null);


### PR DESCRIPTION
## Description
The process of indexing products with many variations, properties, and property attributes consumed a lot of memory.
### Before:
![image](https://github.com/VirtoCommerce/vc-module-catalog/assets/8775253/5deb86ed-16b3-4cc1-8ec5-0c2008f8faae)
### After:
![image](https://github.com/VirtoCommerce/vc-module-catalog/assets/8775253/f8ca440b-ffb9-4078-956c-3c874676f1c9)
## References
### QA-test:
### Jira-link:




https://virtocommerce.atlassian.net/browse/PT-12168
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.272.0-pr-682-5143.zip
