### PR TITLE
Explicitly state response model for the CatalogModuleProducts_GetProductByIds operation

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleProductsController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleProductsController.cs
@@ -86,9 +86,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
         ///<param name="respGroup">Response group.</param>
         [HttpGet]
         [Route("")]
-        [ProducesResponseType(typeof(IEnumerable<CatalogProduct>), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> GetProductByIds([FromQuery] List<string> ids, [FromQuery] string respGroup = null)
+        public async Task<ActionResult<CatalogProduct[]>> GetProductByIds([FromQuery] List<string> ids, [FromQuery] string respGroup = null)
         {
             var items = await _itemsService.GetAsync(ids, respGroup);
             if (items == null)

--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleProductsController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleProductsController.cs
@@ -86,6 +86,8 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
         ///<param name="respGroup">Response group.</param>
         [HttpGet]
         [Route("")]
+        [ProducesResponseType(typeof(IEnumerable<CatalogProduct>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
         public async Task<ActionResult> GetProductByIds([FromQuery] List<string> ids, [FromQuery] string respGroup = null)
         {
             var items = await _itemsService.GetAsync(ids, respGroup);


### PR DESCRIPTION
The workaround for the performance issue in [CatalogModuleProducts_GetProductByIds ](https://github.com/VirtoCommerce/vc-module-catalog/blob/a5ea494738c69ef696dd0ae6fc63560c4ee97c1b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleProductsController.cs#L101-L105) operation has the side effect of missing response type in code model resulting in crippled Swagger spec that states just plain 200, without actual response model:
```json
{
    "/api/catalog/products": {
        "get": {
            "tags": [
                "Catalog"
            ],
            "summary": "Gets products by ids",
            "operationId": "CatalogModuleProducts_GetProductByIds",
            "parameters": "...",         
            "responses": {
                "200": {
                    "description": "Success"
                },
                "401": {
                    "description": "Unauthorized"
                },
                "403": {
                    "description": "Forbidden"
                }
            },
            "security": "..."
        }
    }
}
```
This in turn causes client generators to generate plain `Task` or `void` as return type for the operation, effectively preventing clients from consuming the products response.

After the fix, Swagger spec is enriched with response model reference:
```json
{
    "/api/catalog/products": {
        "get": {
            "tags": [
                "Catalog"
            ],
            "summary": "Gets products by ids",
            "operationId": "CatalogModuleProducts_GetProductByIds",
            "parameters": "...",
            "responses": {
                "200": {
                    "description": "Success",
                    "content": {
                        "text/plain": {
                            "schema": {
                                "type": "array",
                                "items": {
                                    "$ref": "#/components/schemas/CatalogProduct"
                                }
                            }
                        },
                        "application/json": {
                            "schema": {
                                "type": "array",
                                "items": {
                                    "$ref": "#/components/schemas/CatalogProduct"
                                }
                            }
                        },
                        "text/json": {
                            "schema": {
                                "type": "array",
                                "items": {
                                    "$ref": "#/components/schemas/CatalogProduct"
                                }
                            }
                        }
                    }
                },
                "401": {
                    "description": "Unauthorized"
                },
                "403": {
                    "description": "Forbidden"
                },
                "404": {
                    "description": "Not Found"
                }
            },
            "security": "..."
        }
    }
}
```