### PR TITLE
Fix reviews inheritance in catalog product

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/Model/CatalogProduct.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/CatalogProduct.cs
@@ -351,9 +351,8 @@ namespace VirtoCommerce.CatalogModule.Core.Model
 
         protected virtual void InheritReviews(CatalogProduct parentProduct)
         {
-            // Inherit editorial reviews from main product and do not inherit if variation loaded within product
-            var isVariation = GetType().IsAssignableFrom(typeof(Variation));
-            if (!isVariation && Reviews.IsNullOrEmpty() && parentProduct.Reviews != null)
+            // Inherit editorial reviews from main product
+            if (Reviews.IsNullOrEmpty() && parentProduct.Reviews != null)
             {
                 Reviews = new List<EditorialReview>();
                 foreach (var parentReview in parentProduct.Reviews)

--- a/src/VirtoCommerce.CatalogModule.Core/Model/Variation.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/Variation.cs
@@ -2,5 +2,9 @@ namespace VirtoCommerce.CatalogModule.Core.Model
 {
     public class Variation : CatalogProduct
     {
+        protected override void InheritReviews(CatalogProduct parentProduct)
+        {
+            // Do not inherit editorial reviews from main product if variation loaded within product
+        }
     }
 }


### PR DESCRIPTION
Hi, I encountered an issue when loading reviews on `CatalogProduct`. If product has no reviews it should inherit reviews from it's parent. This however does not happen due to following code in `CatalogProduct.InheritReviews`:

```cs
var isVariation = GetType().IsAssignableFrom(typeof(Variation));
```

The `isVariation` will be `true` for instances of `CatalogProduct`. Meaning every `CatalogProduct` is a `Variation` which is not true. The code should be changed to:

```cs
var isVariation = GetType().IsAssignableTo(typeof(Variation));
```

Other approach would be to implement `InheritReviews` on `Variation` instead of checking for concrete type in parent class:

```cs
// CatalogProduct.cs

protected virtual void InheritReviews(CatalogProduct parentProduct)
{
    if (Reviews.IsNullOrEmpty() && parentProduct.Reviews != null)
    {
        // Inherit reviews
    }
}

// Variation.cs

protected override void InheritReviews(CatalogProduct parentProduct)
{
    // Don't inherit reviews if it's a Variation
    return;
}
```
