### PR TITLE
PT-12772: If SearchInVariations is false, ProductSearchRequestBuilder doesn't add "is product" filter.

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductSearchRequestBuilder.cs
@@ -175,7 +175,12 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
             {
                 result.Add(FiltersHelper.CreateTermFilter("is", new[] { "variation", "product" }));
             }
-            else if (!criteria.WithHidden)
+            else
+            {
+                result.Add(FiltersHelper.CreateTermFilter("is", new[] { "product" }));
+            }
+
+            if (!criteria.WithHidden)
             {
                 result.Add(FiltersHelper.CreateTermFilter("status", "visible"));
             }

--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductSearchRequestBuilder.cs
@@ -173,14 +173,14 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
 
             if (criteria.SearchInVariations)
             {
-                result.Add(FiltersHelper.CreateTermFilter("is", new[] { "variation", "product" }));
+                result.Add(FiltersHelper.CreateTermFilter("is", new[] { "product", "variation" }));
             }
             else
             {
                 result.Add(FiltersHelper.CreateTermFilter("is", new[] { "product" }));
             }
 
-            if (!criteria.WithHidden)
+            if (!criteria.WithHidden && !criteria.SearchInVariations)
             {
                 result.Add(FiltersHelper.CreateTermFilter("status", "visible"));
             }


### PR DESCRIPTION
## Description
fix: If SearchInVariations is false, ProductSearchRequestBuilder doesn't add "is product" filter.

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/PT-12772
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.404.0-pr-693-0f56.zip
