### PR TITLE
PT-13624: Error when user get assiciations for product on PostgreSql

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data.PostgreSql/PostgreSqlCatalogRawDatabaseCommand.cs
+++ b/src/VirtoCommerce.CatalogModule.Data.PostgreSql/PostgreSqlCatalogRawDatabaseCommand.cs
@@ -209,7 +209,7 @@ namespace VirtoCommerce.CatalogModule.Data.PostgreSql
                 commands.ForEach(x => AddArrayParameters(x, "@associatedObjectIds", criteria.AssociatedObjectIds));
             }
 
-            result.TotalCount = await dbContext.ExecuteScalarAsync<int>(countSqlCommand.Text, countSqlCommand.Parameters.ToArray());
+            result.TotalCount = await dbContext.ExecuteScalarAsync<Int32>(countSqlCommand.Text, countSqlCommand.Parameters.ToArray());
             result.Results = criteria.Take > 0
                 ? await dbContext.Set<AssociationEntity>().FromSqlRaw(querySqlCommand.Text, querySqlCommand.Parameters.ToArray()).ToListAsync()
                 : new List<AssociationEntity>();
@@ -310,7 +310,7 @@ namespace VirtoCommerce.CatalogModule.Data.PostgreSql
                     Item_CTE AS
                     (
                         SELECT
-                            uuid_generate_v4()::text as Id
+                            a.""Id""
                             ,a.""AssociationType""
                             ,a.""Priority""
                             ,a.""ItemId""


### PR DESCRIPTION
## Description
fix: Error "GraphQL.Execution.UnhandledError: Error trying to resolve field 'associations'.\\n ---> System.InvalidCastException: Unable to cast object of type 'System.Int64' to type 'System.Int32' when user get assiciations for product on PostgreSql.


## References
### QA-test:
### Jira-link:
### Artifact URL:
