### PR TITLE
PT-13660: add productFamilyId index property

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductDocumentBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductDocumentBuilder.cs
@@ -48,6 +48,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
             schema.AddFilterableString("vendor");
             schema.AddFilterableString("productType");
             schema.AddFilterableString("mainProductId");
+            schema.AddFilterableString("productFamilyId");
             schema.AddFilterableString("gtin");
             schema.AddFilterableString("availability");
 
@@ -157,6 +158,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
             document.AddFilterableString("vendor", product.Vendor ?? string.Empty);
             document.AddFilterableString("productType", product.ProductType ?? string.Empty);
             document.AddFilterableString("mainProductId", product.MainProductId ?? string.Empty);
+            document.AddFilterableString("productFamilyId", string.IsNullOrEmpty(product.MainProductId) ? product.Id : product.MainProductId);
             document.AddFilterableString("gtin", product.Gtin ?? string.Empty);
 
             var productAvailability = GetProductAvailability(product);


### PR DESCRIPTION
## Description
To get Main Product and all its variation in one query by `productfamilyid`: 
```
{
  products(
    storeId:"Electronics"  
    filter: "productfamilyid:6e7a31c35c814fb389dc2574aa142b63 status:hidden,visible")
  {
    totalCount
    items
    {
      
      id
      code
      name
    }
  }
}
```

productFamilyId == mainProductId

![Screenshot_23](https://github.com/VirtoCommerce/vc-module-catalog/assets/20122385/0fcfa728-cc86-4d1c-888c-dfbcf3299c44)


## References
### QA-test:
### Jira-link:
### Artifact URL:
