### PR TITLE
variation image inherits id from parent product image

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/Model/AssetBase.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/AssetBase.cs
@@ -79,7 +79,7 @@ namespace VirtoCommerce.CatalogModule.Core.Model
         {
             if (parent is AssetBase parentAssetBase)
             {
-                Id = null;
+                Id = parentAssetBase.Id;
                 IsInherited = true;
                 LanguageCode = parentAssetBase.LanguageCode;
                 Name = parentAssetBase.Name;


### PR DESCRIPTION
## Description
If requesting a variation product with images that are saved within the parent product, then the id is manually set to null. This PR is setting id to the parent product image id. That way it will return the same image id as if one would request the parent product image id. 
## References
### QA-test:
### Jira-link:
### Artifact URL:
