### PR TITLE
PT-12758: Exclude 0 as lower bound in price facets if first bound is 0

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogBrowseFiltersController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogBrowseFiltersController.cs
@@ -274,31 +274,43 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
             sortedBounds.Add(null);
 
             string previousBound = null;
-            var isFirstPriceRange = isPriceRange;
+            var isFirstRange = true;
 
             foreach (var bound in sortedBounds)
             {
                 // Don't add a range for negative prices if first bound is 0
-                if (!isFirstPriceRange || bound != "0")
+                if (!isPriceRange || !isFirstRange || bound != "0")
                 {
                     var value = new RangeFilterValue
                     {
-                        Id = isFirstPriceRange ? $"under-{bound}" : bound == null ? $"over-{previousBound}" : $"{previousBound}-{bound}",
+                        Id = GetRangeId(isFirstRange, bound, previousBound),
                         Lower = previousBound,
                         Upper = bound,
                         // Exclude 0 as lower bound for price range if first bound is 0
-                        IncludeLower = !isFirstPriceRange || previousBound != "0",
+                        IncludeLower = !isPriceRange || !isFirstRange || previousBound != "0",
                         IncludeUpper = false,
                     };
 
                     result.Add(value);
-                    isFirstPriceRange = false;
+                    isFirstRange = false;
                 }
 
                 previousBound = bound;
             }
 
             return result.Any() ? result.ToArray() : null;
+        }
+
+        private static string GetRangeId(bool isFirstRange, string bound, string previousBound)
+        {
+            if (isFirstRange)
+            {
+                return $"under-{bound}";
+            }
+
+            return bound == null
+                ? $"over-{previousBound}"
+                : $"{previousBound}-{bound}";
         }
 
         private static IEnumerable<string> SortStringsAsNumbers(IEnumerable<string> strings)

--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogBrowseFiltersController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogBrowseFiltersController.cs
@@ -308,9 +308,9 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
                 return $"under-{bound}";
             }
 
-            return bound == null
-                ? $"over-{previousBound}"
-                : $"{previousBound}-{bound}";
+            return bound != null
+                ? $"{previousBound}-{bound}"
+                : $"over-{previousBound}";
         }
 
         private static IEnumerable<string> SortStringsAsNumbers(IEnumerable<string> strings)


### PR DESCRIPTION
## Description
If you want to exclude products with zero price from aggregations, you should add 0 as first range bound:
<img width="728" alt="image" src="https://github.com/VirtoCommerce/vc-module-catalog/assets/8775253/94819994-49e5-482b-8f51-f7b9cb7401b1">

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-12758
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.412.0-pr-704-5c9a.zip
