### PR TITLE
PT-14218: Support different search provider for each document type

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/VirtoCommerce.CatalogModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogModule.Core/VirtoCommerce.CatalogModule.Core.csproj
@@ -19,6 +19,6 @@
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.ExportModule.Core" Version="3.200.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.413.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.723-pt-14218" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogModule.Core/VirtoCommerce.CatalogModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogModule.Core/VirtoCommerce.CatalogModule.Core.csproj
@@ -19,6 +19,6 @@
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.ExportModule.Core" Version="3.200.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.413.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.401.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.719-pt-14218" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogModule.Core/VirtoCommerce.CatalogModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogModule.Core/VirtoCommerce.CatalogModule.Core.csproj
@@ -19,6 +19,6 @@
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.400.0" />
     <PackageReference Include="VirtoCommerce.ExportModule.Core" Version="3.200.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.413.0" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.719-pt-14218" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.723-pt-14218" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogModule.Web/module.manifest
@@ -3,15 +3,17 @@
   <id>VirtoCommerce.Catalog</id>
   <version>3.414.0</version>
   <version-tag />
+
   <platformVersion>3.413.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.400.0" />
     <dependency id="VirtoCommerce.BulkActionsModule" version="3.200.0" />
     <dependency id="VirtoCommerce.Core" version="3.400.0" />
     <dependency id="VirtoCommerce.Export" version="3.200.0" />
-    <dependency id="VirtoCommerce.Search" version="3.401.0" />
+    <dependency id="VirtoCommerce.Search" version="3.403.0" />
     <dependency id="VirtoCommerce.Store" version="3.400.0" />
   </dependencies>
+
   <title>Catalog</title>
   <description>Easily manage your products, categories, variations, and properties</description>
   <authors>


### PR DESCRIPTION
## Description
Configuration example for default provider `ElasticAppSearch` and category provider `ElasticSearch8`:
```
{
  "Search": {
    "Provider": "ElasticAppSearch",
    "DocumentScopes": [
      {
        "DocumentType": "Category",
        "Provider": "ElasticSearch8"
      }
    ]
  }
}
```
## References
### QA-test:
### Jira-link:





https://virtocommerce.atlassian.net/browse/PT-14218
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.417.0-pr-706-3bf0.zip
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.414.0-pr-706-3d21.zip
