### PR TITLE
PT-14632: Fixs search in variations by keyword.

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/Model/Search/Indexed/ProductIndexedSearchCriteria.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/Search/Indexed/ProductIndexedSearchCriteria.cs
@@ -83,6 +83,7 @@ namespace VirtoCommerce.CatalogModule.Core.Model.Search
             }
 
             WithHidden = !listEntryCriteria.HideDirectLinkedCategories;
+            SearchInVariations = listEntryCriteria.SearchInVariations;
 
             return base.FromListEntryCriteria(listEntryCriteria);
         }


### PR DESCRIPTION
## Description
fix: Either Admin Back Offrice or api/catalog/listentries return main product when user try to find variation by keyword.

![PT-14632](https://github.com/VirtoCommerce/vc-module-catalog/assets/7639413/494ad947-1e8b-4616-b5c0-2d5a0db74511)

## References
### QA-test:
### Jira-link:
### Artifact URL:
