### PR TITLE
VCST-197: remove extra permissions

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModulePropertyDictionaryItemsController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModulePropertyDictionaryItemsController.cs
@@ -52,7 +52,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
         /// </summary>
         [HttpPost]
         [Route("")]
-        [Authorize(ModuleConstants.Security.Permissions.Create)]
+        [Authorize(ModuleConstants.Security.Permissions.CatalogDictionaryPropertyEdit)]
         public async Task<ActionResult> SaveChanges([FromBody] PropertyDictionaryItem[] propertyDictItems)
         {
             var authorizationResult = await _authorizationService.AuthorizeAsync(User, propertyDictItems, new CatalogAuthorizationRequirement(ModuleConstants.Security.Permissions.CatalogDictionaryPropertyEdit));
@@ -70,7 +70,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
         /// <param name="ids">The identifiers of objects that needed to be deleted</param>
         [HttpDelete]
         [Route("")]
-        [Authorize(ModuleConstants.Security.Permissions.Delete)]
+        [Authorize(ModuleConstants.Security.Permissions.CatalogDictionaryPropertyEdit)]
         public async Task<ActionResult> DeletePropertyDictionaryItems([FromQuery] string[] ids)
         {
             var criteria = new PropertyDictionaryItemSearchCriteria { PropertyIds = ids };

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-detail.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-detail.js
@@ -1,7 +1,7 @@
 angular.module('virtoCommerce.catalogModule')
     .controller('virtoCommerce.catalogModule.propertyDetailController', ['$scope', '$q', 'virtoCommerce.catalogModule.properties', 'platformWebApp.bladeNavigationService', 'platformWebApp.dialogService', 'virtoCommerce.catalogModule.valueTypes', 'virtoCommerce.catalogModule.propertyValidators', function ($scope, $q, properties, bladeNavigationService, dialogService, valueTypes, propertyValidators) {
         var blade = $scope.blade;
-        blade.updatePermission = 'catalog:update';
+        blade.updatePermission = 'catalog:metadata-property:edit';
         blade.origEntity = {};
         $scope.currentChild = undefined;
         blade.title = "catalog.blades.property-detail.title";

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-dictionary-details.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-dictionary-details.js
@@ -8,6 +8,7 @@ angular.module('virtoCommerce.catalogModule')
             $scope.blade.isLoading = false;
             $scope.validationRules = blade.property.validationRule;
 
+            var hasEditDictionaryPermission = bladeNavigationService.checkPermission('catalog:dictionary-property:edit');
 
             $scope.setForm = function (form) { blade.formScope = form; }
 
@@ -25,7 +26,7 @@ angular.module('virtoCommerce.catalogModule')
             };
 
             function isDirty() {
-                return !angular.equals(blade.currentEntity, blade.origEntity) && blade.hasUpdatePermission();
+                return !angular.equals(blade.currentEntity, blade.origEntity) && hasEditDictionaryPermission;
             }
 
             function canSave() {

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-dictionary-details.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-dictionary-details.js
@@ -3,12 +3,11 @@ angular.module('virtoCommerce.catalogModule')
         ['$scope', 'platformWebApp.dialogService', 'platformWebApp.bladeNavigationService', 'virtoCommerce.catalogModule.propDictItems', function ($scope, dialogService, bladeNavigationService, propDictItems) {
             var blade = $scope.blade;
             blade.headIcon = 'fa fa-book';
+            blade.updatePermission = 'catalog:dictionary-property:edit';
 
             $scope.isValid = true;
             $scope.blade.isLoading = false;
             $scope.validationRules = blade.property.validationRule;
-
-            var hasEditDictionaryPermission = bladeNavigationService.checkPermission('catalog:dictionary-property:edit');
 
             $scope.setForm = function (form) { blade.formScope = form; }
 
@@ -26,7 +25,7 @@ angular.module('virtoCommerce.catalogModule')
             };
 
             function isDirty() {
-                return !angular.equals(blade.currentEntity, blade.origEntity) && hasEditDictionaryPermission;
+                return !angular.equals(blade.currentEntity, blade.origEntity) && blade.hasUpdatePermission();
             }
 
             function canSave() {


### PR DESCRIPTION
## Description

remove the 'catalog:create' and 'catalog:delete' permissions for the edit dictionary item action

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-197
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.801.0-pr-717-ca65.zip
