### PR TITLE
VCST-881: PriceRange Aggregation is not functioning as expected.

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/AggregationConverter.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/AggregationConverter.cs
@@ -279,16 +279,17 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
 
         protected virtual Aggregation GetPriceRangeAggregation(PriceRangeFilter priceRangeFilter, IList<AggregationResponse> aggregationResponses)
         {
-            var fieldName = "price";
+            var rangeAggregations = new List<AggregationResponse>();
 
-            var priceValues = aggregationResponses.Where(a => a.Id.StartsWith(fieldName)).SelectMany(x => x.Values).ToArray();
+            // Merge All Virtual Price Ranges in rangeAggregations
+            var priceFieldName = "price";
+
+            var priceValues = aggregationResponses.Where(a => a.Id.StartsWith(priceFieldName)).SelectMany(x => x.Values).ToArray();
 
             if (priceValues.Length == 0)
             {
                 return null;
             }
-
-            var rangeAggregations = new List<AggregationResponse>();
 
             var matchIdRegEx = new Regex(@"^(?<left>[0-9*]+)-(?<right>[0-9*]+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
@@ -299,7 +300,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
                 var right = matchId.Groups["right"].Value;
                 x.Id = left == "*" ? $@"under-{right}" : x.Id;
                 x.Id = right == "*" ? $@"over-{left}" : x.Id;
-                return new AggregationResponse { Id = $@"{fieldName}-{x.Id}", Values = new List<AggregationResponseValue> { x } };
+                return new AggregationResponse { Id = $@"{priceFieldName}-{x.Id}", Values = new List<AggregationResponseValue> { x } };
             }));
 
 

--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/AggregationConverter.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/AggregationConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.CatalogModule.Core;
@@ -278,11 +279,35 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
 
         protected virtual Aggregation GetPriceRangeAggregation(PriceRangeFilter priceRangeFilter, IList<AggregationResponse> aggregationResponses)
         {
+            var fieldName = "price";
+
+            var priceValues = aggregationResponses.Where(a => a.Id.StartsWith(fieldName)).SelectMany(x => x.Values).ToArray();
+
+            if (priceValues.Length == 0)
+            {
+                return null;
+            }
+
+            var rangeAggregations = new List<AggregationResponse>();
+
+            var matchIdRegEx = new Regex(@"^(?<left>[0-9*]+)-(?<right>[0-9*]+)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+            rangeAggregations.AddRange(priceValues.Select(x =>
+            {
+                var matchId = matchIdRegEx.Match(x.Id);
+                var left = matchId.Groups["left"].Value;
+                var right = matchId.Groups["right"].Value;
+                x.Id = left == "*" ? $@"under-{right}" : x.Id;
+                x.Id = right == "*" ? $@"over-{left}" : x.Id;
+                return new AggregationResponse { Id = $@"{fieldName}-{x.Id}", Values = new List<AggregationResponseValue> { x } };
+            }));
+
+
             var result = new Aggregation
             {
                 AggregationType = "pricerange",
                 Field = priceRangeFilter.Key,
-                Items = GetRangeAggregationItems(priceRangeFilter.Key, priceRangeFilter.Values, aggregationResponses).ToArray(),
+                Items = GetRangeAggregationItems(priceRangeFilter.Key, priceRangeFilter.Values, rangeAggregations).ToArray(),
             };
 
 


### PR DESCRIPTION
## Description
fix: Fixed the issue where the price range aggregation property was not being included in the response of the /api/catalog/search/products.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-881
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.807.0-pr-726-c4a0.zip