### PR TITLE
Ensure that saved editorial reviews are not marked as inherited

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/editorialReview-detail.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/editorialReview-detail.js
@@ -28,8 +28,9 @@ angular.module('virtoCommerce.catalogModule')
             var existReview = _.find(blade.item.reviews, function (x) { return x == blade.origEntity; });
             if (!existReview) {
                 blade.item.reviews.push(blade.origEntity);
-            };
+            }
             angular.copy(blade.currentEntity, blade.origEntity);
+            blade.currentEntity.isInherited = false;
             $scope.bladeClose();
         };
 
@@ -102,9 +103,10 @@ angular.module('virtoCommerce.catalogModule')
             var existReview = _.find(blade.item.reviews, function (x) { return x === blade.origEntity; });
             if (!existReview) {
                 blade.item.reviews.push(blade.origEntity);
-            };
+            }
 
             angular.copy(blade.currentEntity, blade.origEntity);
+            blade.currentEntity.isInherited = false;
         }
 
         function isDirty() {

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/editorialReview-detail.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/editorialReview-detail.js
@@ -3,7 +3,7 @@ angular.module('virtoCommerce.catalogModule')
     function ($scope, bladeNavigationService, FileUploader, settings, $timeout) {
         var blade = $scope.blade;
 
-        function initilize() {
+        function initialize() {
             if (!blade.item.reviews) {
                 blade.item.reviews = [];
             }
@@ -23,16 +23,6 @@ angular.module('virtoCommerce.catalogModule')
         }
 
         $scope.isValid = true;
-
-        $scope.saveChanges = function () {
-            var existReview = _.find(blade.item.reviews, function (x) { return x == blade.origEntity; });
-            if (!existReview) {
-                blade.item.reviews.push(blade.origEntity);
-            }
-            angular.copy(blade.currentEntity, blade.origEntity);
-            blade.currentEntity.isInherited = false;
-            $scope.bladeClose();
-        };
 
         blade.headIcon = 'fa fa-comments';
         blade.title = 'catalog.blades.editorialReview-detail.title';
@@ -105,8 +95,8 @@ angular.module('virtoCommerce.catalogModule')
                 blade.item.reviews.push(blade.origEntity);
             }
 
-            angular.copy(blade.currentEntity, blade.origEntity);
             blade.currentEntity.isInherited = false;
+            angular.copy(blade.currentEntity, blade.origEntity);
         }
 
         function isDirty() {
@@ -121,5 +111,5 @@ angular.module('virtoCommerce.catalogModule')
             bladeNavigationService.showConfirmationIfNeeded(isDirty(), canSave(), blade, saveChanges, closeCallback, "catalog.dialogs.review-save.title", "catalog.dialogs.review-save.message");
         };
 
-        initilize();
+        initialize();
     }]);


### PR DESCRIPTION
When I have a product variation that inherit reviews (descriptions) from the parent, these reviews are editable, but the edits won't get persisted in the database - they get silently dropped without a warning. This behavior is due to the fact that those edited inherited reviews are ignored when mapping `CatalogProduct` to `ItemService` - [there's a filter](https://github.com/VirtoCommerce/vc-module-catalog/blob/f55012d8b82928a681dc1b3d2ef01b44ff818beb/src/VirtoCommerce.CatalogModule.Data/Model/ItemEntity.cs#L356) on `EditorialReview.IsInherited` property.

This PR offers a small change in the UI code, that clears the `isInherited` flag on those editorial reviews that got saved, effectively promoting them to variation's own reviews. In effect, the user can now directly override inherited reviews in variants.