### PR TITLE
VCST-1759: Drop the requirement for product associations search criteria to have at least one object id

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data.PostgreSql/PostgreSqlCatalogRawDatabaseCommand.cs
+++ b/src/VirtoCommerce.CatalogModule.Data.PostgreSql/PostgreSqlCatalogRawDatabaseCommand.cs
@@ -242,32 +242,61 @@ namespace VirtoCommerce.CatalogModule.Data.PostgreSql
             var command = new StringBuilder();
 
             command.Append(@"
-                ; WITH RECURSIVE Association_CTE AS
-                (
-                    SELECT a.*
-                    FROM ""Association"" a");
+                    ;WITH RECURSIVE Association_CTE AS
+                    (
+                        SELECT
+                             a.""Id""
+                            ,a.""AssociationType""
+                            ,a.""Priority""
+                            ,a.""ItemId""
+                            ,a.""CreatedDate""
+                            ,a.""ModifiedDate""
+                            ,a.""CreatedBy""
+                            ,a.""ModifiedBy""
+                            ,a.""AssociatedItemId""
+                            ,a.""AssociatedCategoryId""
+                            ,a.""Tags""
+                            ,a.""Quantity""
+                            ,a.""OuterId""
+                        FROM ""Association"" a"
+            );
 
             AddAssociationsSearchCriteriaToCommand(command, criteria);
 
             command.Append(@"), Category_CTE AS
-                (
-                    SELECT ""AssociatedCategoryId"" Id
-                    FROM Association_CTE
-                    WHERE ""AssociatedCategoryId"" IS NOT NULL
-                    UNION ALL
-                    SELECT c.""Id""
-                    FROM ""Category"" c
-                    INNER JOIN Category_CTE cte ON c.""ParentCategoryId"" = cte.Id
-                ),
-                Item_CTE AS
-                (
-                    SELECT  i.""Id""
-                    FROM (SELECT DISTINCT Id FROM Category_CTE) c
-                    LEFT JOIN ""Item"" i ON c.Id=i.""CategoryId"" WHERE i.""ParentId"" IS NULL
-                    UNION
-                    SELECT ""AssociatedItemId"" Id FROM Association_CTE
-                )
-                SELECT COUNT(""Id"") FROM Item_CTE");
+                    (
+                        SELECT ""AssociatedCategoryId"" Id, ""AssociatedCategoryId""
+                        FROM Association_CTE
+                        WHERE ""AssociatedCategoryId"" IS NOT NULL
+                        UNION ALL
+                        SELECT c.""Id"", cte.""AssociatedCategoryId""
+                        FROM ""Category"" c
+                        INNER JOIN Category_CTE cte ON c.""ParentCategoryId"" = cte.Id
+                    ),
+                    Item_CTE AS
+                    (
+                        SELECT
+                            a.""Id""
+                            ,a.""AssociationType""
+                            ,a.""Priority""
+                            ,a.""ItemId""
+                            ,a.""CreatedDate""
+                            ,a.""ModifiedDate""
+                            ,a.""CreatedBy""
+                            ,a.""ModifiedBy""
+                            ,i.""Id"" ""AssociatedItemId""
+                            ,a.""AssociatedCategoryId""
+                            ,a.""Tags""
+                            ,a.""Quantity""
+                            ,a.""OuterId""
+                        FROM Category_CTE cat
+                        LEFT JOIN ""Item"" i ON cat.Id=i.""CategoryId""
+                        LEFT JOIN ""Association"" a ON cat.""AssociatedCategoryId""=a.""AssociatedCategoryId""
+                        WHERE i.""ParentId"" IS NULL
+                        UNION
+                        SELECT * FROM Association_CTE
+                    )
+                    SELECT COUNT(*) FROM Item_CTE WHERE ""AssociatedItemId"" IS NOT NULL ");
 
             return command.ToString();
         }

--- a/src/VirtoCommerce.CatalogModule.Data.SqlServer/SqlServerCatalogRawDatabaseCommand.cs
+++ b/src/VirtoCommerce.CatalogModule.Data.SqlServer/SqlServerCatalogRawDatabaseCommand.cs
@@ -241,32 +241,61 @@ namespace VirtoCommerce.CatalogModule.Data.SqlServer
             var command = new StringBuilder();
 
             command.Append(@"
-                ; WITH Association_CTE AS
-                (
-                    SELECT a.*
-                    FROM Association a");
+                    ;WITH Association_CTE AS
+                    (
+                        SELECT
+                             a.Id
+                            ,a.AssociationType
+                            ,a.Priority
+                            ,a.ItemId
+                            ,a.CreatedDate
+                            ,a.ModifiedDate
+                            ,a.CreatedBy
+                            ,a.ModifiedBy
+                            ,a.AssociatedItemId
+                            ,a.AssociatedCategoryId
+                            ,a.Tags
+                            ,a.Quantity
+                            ,a.OuterId
+                        FROM Association a"
+            );
 
             AddAssociationsSearchCriteraToCommand(command, criteria);
 
             command.Append(@"), Category_CTE AS
-                (
-                    SELECT AssociatedCategoryId Id
-                    FROM Association_CTE
-                    WHERE AssociatedCategoryId IS NOT NULL
-                    UNION ALL
-                    SELECT c.Id
-                    FROM Category c
-                    INNER JOIN Category_CTE cte ON c.ParentCategoryId = cte.Id
-                ),
-                Item_CTE AS
-                (
-                    SELECT  i.Id
-                    FROM (SELECT DISTINCT Id FROM Category_CTE) c
-                    LEFT JOIN Item i ON c.Id=i.CategoryId WHERE i.ParentId IS NULL
-                    UNION
-                    SELECT AssociatedItemId Id FROM Association_CTE
-                )
-                SELECT COUNT(Id) FROM Item_CTE");
+                    (
+                        SELECT AssociatedCategoryId Id, AssociatedCategoryId, Id AssociationId
+                        FROM Association_CTE
+                        WHERE AssociatedCategoryId IS NOT NULL
+                        UNION ALL
+                        SELECT c.Id, cte.AssociatedCategoryId, cte.AssociationId
+                        FROM Category c
+                        INNER JOIN Category_CTE cte ON c.ParentCategoryId = cte.Id
+                    ),
+                    Item_CTE AS
+                    (
+                        SELECT
+                            CONVERT(nvarchar(64), newid()) as Id
+                            ,a.AssociationType
+                            ,a.Priority
+                            ,a.ItemId
+                            ,a.CreatedDate
+                            ,a.ModifiedDate
+                            ,a.CreatedBy
+                            ,a.ModifiedBy
+                            ,i.Id AssociatedItemId
+                            ,a.AssociatedCategoryId
+                            ,a.Tags
+                            ,a.Quantity
+                            ,a.OuterId
+                        FROM Category_CTE cat
+                        LEFT JOIN Item i ON cat.Id=i.CategoryId
+                        LEFT JOIN Association a ON cat.AssociationId = a.Id
+                        WHERE i.ParentId IS NULL
+                        UNION
+                        SELECT * FROM Association_CTE
+                    )
+                    SELECT COUNT(*) FROM Item_CTE WHERE AssociatedItemId IS NOT NULL");
 
             return command.ToString();
         }

--- a/src/VirtoCommerce.CatalogModule.Data/Search/ProductAssociationSearchService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/ProductAssociationSearchService.cs
@@ -23,7 +23,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search
             _platformMemoryCache = platformMemoryCache;
         }
 
-        public async Task<ProductAssociationSearchResult> SearchProductAssociationsAsync(ProductAssociationSearchCriteria criteria)
+        public Task<ProductAssociationSearchResult> SearchProductAssociationsAsync(ProductAssociationSearchCriteria criteria)
         {
             if (criteria == null)
             {
@@ -31,11 +31,11 @@ namespace VirtoCommerce.CatalogModule.Data.Search
             }
 
             var cacheKey = CacheKey.With(GetType(), "SearchProductAssociationsAsync", criteria.GetCacheKey());
-            return await _platformMemoryCache.GetOrCreateExclusiveAsync(cacheKey, async (cacheEntry) =>
+            return _platformMemoryCache.GetOrCreateExclusiveAsync(cacheKey, async (cacheEntry) =>
             {
                 cacheEntry.AddExpirationToken(AssociationSearchCacheRegion.CreateChangeToken());
                 var result = AbstractTypeFactory<ProductAssociationSearchResult>.TryCreateInstance();
-                if (!criteria.ObjectIds.IsNullOrEmpty())
+                if (!criteria.ObjectIds.IsNullOrEmpty() || !criteria.AssociatedObjectIds.IsNullOrEmpty())
                 {
                     using (var repository = _catalogRepositoryFactory())
                     {


### PR DESCRIPTION
## Description
feat: Drop the requirement for product associations search criteria to have at least one object id. ProductAssociationSearchCriteria should have at least one ObjectIds or AssociatedObjectIds.

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-1759
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.818.0-pr-741-e1f2.zip