### PR TITLE
VCST-1845: Indexing fails due to a null reference exception

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductDocumentBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/ProductDocumentBuilder.cs
@@ -259,7 +259,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
         {
             foreach (var review in reviews.Where(x => !string.IsNullOrEmpty(x?.Content)))
             {
-                var descriptionField = $"description_{review.ReviewType.ToLowerInvariant()}_{review.LanguageCode.ToLowerInvariant()}";
+                var descriptionField = $"description_{review.ReviewType?.ToLowerInvariant() ?? "null"}_{review.LanguageCode?.ToLowerInvariant() ?? "null"}";
                 document.Add(new IndexDocumentField(descriptionField, review.Content, IndexDocumentFieldValueType.String) { IsRetrievable = true, IsCollection = true });
             }
         }

--- a/src/VirtoCommerce.CatalogModule.Data/Search/ProductAssociationSearchService.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/ProductAssociationSearchService.cs
@@ -23,7 +23,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search
             _platformMemoryCache = platformMemoryCache;
         }
 
-        public Task<ProductAssociationSearchResult> SearchProductAssociationsAsync(ProductAssociationSearchCriteria criteria)
+        public async Task<ProductAssociationSearchResult> SearchProductAssociationsAsync(ProductAssociationSearchCriteria criteria)
         {
             if (criteria == null)
             {
@@ -31,7 +31,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search
             }
 
             var cacheKey = CacheKey.With(GetType(), "SearchProductAssociationsAsync", criteria.GetCacheKey());
-            return _platformMemoryCache.GetOrCreateExclusiveAsync(cacheKey, async (cacheEntry) =>
+            return await _platformMemoryCache.GetOrCreateExclusiveAsync(cacheKey, async (cacheEntry) =>
             {
                 cacheEntry.AddExpirationToken(AssociationSearchCacheRegion.CreateChangeToken());
                 var result = AbstractTypeFactory<ProductAssociationSearchResult>.TryCreateInstance();


### PR DESCRIPTION
## Description
fix: Product index document builder fails when a product has an editorial review (description) with a null type or language code.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-1845
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.819.0-pr-744-c17d.zip