### PR TITLE
VCST-2186: context menu won't disappear after deletion

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/images.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/images.js
@@ -46,7 +46,17 @@ angular.module('virtoCommerce.catalogModule')
                 $scope.removeItem = function(image) {
                     var idx = blade.currentEntities.indexOf(image);
                     if (idx >= 0) {
-                        blade.currentEntities.splice(idx, 1);
+                        var dialog = {
+                            id: "confirmDeleteItem",
+                            title: "platform.dialogs.folders-delete.title",
+                            message: "platform.dialogs.folders-delete.message",
+                            callback: function (remove) {
+                                if (remove) {
+                                    blade.currentEntities.splice(idx, 1);
+                                }
+                            }
+                        }
+                        dialogService.showConfirmationDialog(dialog);
                     }
                 };
 
@@ -70,13 +80,22 @@ angular.module('virtoCommerce.catalogModule')
                         selectedImages = $scope.gridApi.selection.getSelectedRows();
                     }
 
-                    angular.forEach(selectedImages,
-                        function(image) {
-                            var idx = blade.currentEntities.indexOf(image);
-                            if (idx >= 0) {
-                                blade.currentEntities.splice(idx, 1);
+                    var dialog = {
+                        id: "confirmDeleteItem",
+                        title: "platform.dialogs.folders-delete.title",
+                        message: "platform.dialogs.folders-delete.message",
+                        callback: function (remove) {
+                            if (remove) {
+                                angular.forEach(selectedImages, function (image) {
+                                    var idx = blade.currentEntities.indexOf(image);
+                                    if (idx >= 0) {
+                                        blade.currentEntities.splice(idx, 1);
+                                    }
+                                });
                             }
-                        });
+                        }
+                    }
+                    dialogService.showConfirmationDialog(dialog);
                 };
 
                 $scope.edit = function(entity) {

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/item-asset-list.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/item-asset-list.js
@@ -1,5 +1,6 @@
 angular.module('virtoCommerce.catalogModule')
-    .controller('virtoCommerce.catalogModule.itemAssetController', ['$scope', '$translate', 'platformWebApp.bladeNavigationService', '$filter', 'platformWebApp.uiGridHelper', '$timeout', 'platformWebApp.settings', function ($scope, $translate, bladeNavigationService, $filter, uiGridHelper, $timeout, settings) {
+    .controller('virtoCommerce.catalogModule.itemAssetController', ['$scope', '$translate', 'platformWebApp.bladeNavigationService', '$filter', 'platformWebApp.uiGridHelper', '$timeout', 'platformWebApp.settings', 'platformWebApp.dialogService',
+        function ($scope, $translate, bladeNavigationService, $filter, uiGridHelper, $timeout, settings, dialogService) {
         var blade = $scope.blade;
         blade.headIcon = 'fa fa-chain';
 
@@ -158,7 +159,17 @@ angular.module('virtoCommerce.catalogModule')
         $scope.removeItem = function (image) {
             var idx = blade.currentEntities.indexOf(image);
             if (idx >= 0) {
-                blade.currentEntities.splice(idx, 1);
+                var dialog = {
+                    id: "confirmDeleteItem",
+                    title: "platform.dialogs.folders-delete.title",
+                    message: "platform.dialogs.folders-delete.message",
+                    callback: function (remove) {
+                        if (remove) {
+                            blade.currentEntities.splice(idx, 1);
+                        }
+                    }
+                }
+                dialogService.showConfirmationDialog(dialog);
             }
         };
 
@@ -172,12 +183,22 @@ angular.module('virtoCommerce.catalogModule')
                 selectedImages = $scope.gridApi.selection.getSelectedRows();
             }
 
-            angular.forEach(selectedImages, function (image) {
-                var idx = blade.currentEntities.indexOf(image);
-                if (idx >= 0) {
-                    blade.currentEntities.splice(idx, 1);
+            var dialog = {
+                id: "confirmDeleteItem",
+                title: "platform.dialogs.folders-delete.title",
+                message: "platform.dialogs.folders-delete.message",
+                callback: function (remove) {
+                    if (remove) {
+                        angular.forEach(selectedImages, function (image) {
+                            var idx = blade.currentEntities.indexOf(image);
+                            if (idx >= 0) {
+                                blade.currentEntities.splice(idx, 1);
+                            }
+                        });
+                    }
                 }
-            });
+            }
+            dialogService.showConfirmationDialog(dialog);
         };
 
         initialize(blade.item);


### PR DESCRIPTION
## Description
fix: Resolve the issue that the context menu won't disappear after deletion for product assets.
feat: Added confirmation dialog before deleting operation for product asset.

![image](https://github.com/user-attachments/assets/800415e3-83b6-4d15-ac2a-db4456717682)

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-2186
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.828.0-pr-756-0c3e.zip