### PR TITLE
VCST-2253: Error trying to resolve field associations. column itemid does not exist

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data.PostgreSql/PostgreSqlCatalogRawDatabaseCommand.cs
+++ b/src/VirtoCommerce.CatalogModule.Data.PostgreSql/PostgreSqlCatalogRawDatabaseCommand.cs
@@ -380,7 +380,7 @@ namespace VirtoCommerce.CatalogModule.Data.PostgreSql
             if (!criteria.ObjectIds.IsNullOrEmpty())
             {
                 command.Append(@"
-                    WHERE ItemId IN ({0})
+                    WHERE ""ItemId"" IN ({0})
                 ");
 
                 // search by associated product ids


### PR DESCRIPTION
## Description
fix: Error trying to resolve field associations. column itemid does not exist

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2253
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.827.0-pr-757-70b5.zip