### PR TITLE
VCST-2554: Wrong Padding in Product Gray Box

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Content/css/catalog.css
+++ b/src/VirtoCommerce.CatalogModule.Web/Content/css/catalog.css
@@ -321,7 +321,7 @@ vc-item-search {
 .blade-gray-box {
     background: #F9F9F9;
     margin: 15px -20px 0 -20px;
-    padding: 5px 20px 30px 20px;
+    padding: 10px 20px 30px 20px;
 }
 .form-input textarea.__xsmall {
     height: 34px;

--- a/src/VirtoCommerce.CatalogModule.Web/Content/css/catalog.css
+++ b/src/VirtoCommerce.CatalogModule.Web/Content/css/catalog.css
@@ -321,7 +321,7 @@ vc-item-search {
 .blade-gray-box {
     background: #F9F9F9;
     margin: 15px -20px 0 -20px;
-    padding: 15px 20px 30px 20px;
+    padding: 5px 20px 30px 20px;
 }
 .form-input textarea.__xsmall {
     height: 34px;

--- a/src/VirtoCommerce.CatalogModule.Web/Content/css/catalog.css
+++ b/src/VirtoCommerce.CatalogModule.Web/Content/css/catalog.css
@@ -321,7 +321,7 @@ vc-item-search {
 .blade-gray-box {
     background: #F9F9F9;
     margin: 15px -20px 0 -20px;
-    padding: 0 20px 30px 20px;
+    padding: 15px 20px 30px 20px;
 }
 .form-input textarea.__xsmall {
     height: 34px;


### PR DESCRIPTION
## Description
Wrong Padding in Product Gray Box. Increase top padding of .blade-gray-box to 15px. This change will add more space at the top of elements with this class, improving the visual layout and spacing within the user interface.

![image](https://github.com/user-attachments/assets/fbd3f1f5-a5a8-498f-8764-4addf5eb2c7d)

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-2554
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.835.0-pr-765-ef3d.zip