### PR TITLE
VCST-3176: Prevent duplicate properties with the same name and type from being added to the category

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Validation/CategoryPropertyNameValidator.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Validation/CategoryPropertyNameValidator.cs
@@ -29,35 +29,15 @@ namespace VirtoCommerce.CatalogModule.Data.Validation
 
         private void AttachValidators()
         {
-            // 1. Catalog: Prevent adding a property that already exists in the category or is inherited from either parent category or catalog.
-            RuleFor(r => r)
-              .CustomAsync(async (r, context, _) =>
-              {
-                  var (isPropertyUniqueForHierarchy, categoryName) = await CheckPropertyUniquenessInCategoryAsync(r);
-
-                  if (!isPropertyUniqueForHierarchy)
-                  {
-                      context.AddFailure(new ValidationFailure(r.PropertyName, "duplicate-property")
-                      {
-                          CustomState = new
-                          {
-                              PropertyName = r.PropertyName,
-                              CategoryName = categoryName,
-                          },
-                      });
-                  }
-              });
-
-
-            // 2. Global: Ensure that properties with the same name across the all catalogs have the same type to prevent indexing issues.
+            // 1. Global: Ensure that properties with the same name across the all catalogs have the same type to prevent indexing issues.
             RuleFor(r => r)
                .CustomAsync(async (r, context, _) =>
                {
-                   var (isPropertyUniqueForInstance, categoryName) = await CheckPropertyUniquenessAsync(r);
+                   var (isPropertyUnique, categoryName) = await CheckPropertyUniquenessInGlobalAsync(r);
 
-                   if (!isPropertyUniqueForInstance)
+                   if (!isPropertyUnique)
                    {
-                       context.AddFailure(new ValidationFailure(r.PropertyName, "property-type-name-global-issue")
+                       context.AddFailure(new ValidationFailure(r.PropertyName, "global-property-name-type")
                        {
                            CustomState = new
                            {
@@ -68,9 +48,59 @@ namespace VirtoCommerce.CatalogModule.Data.Validation
                    }
                });
 
+            // 2. Catalog: Prevent adding a property that already exists in the current category or catalog.
+            RuleFor(r => r)
+              .CustomAsync(async (r, context, _) =>
+              {
+                  var (isPropertyUnique, categoryName) = await CheckPropertyUniquenessInParentAsync(r);
+
+                  if (!isPropertyUnique)
+                  {
+                      context.AddFailure(new ValidationFailure(r.PropertyName, "duplicated-property")
+                      {
+                          CustomState = new
+                          {
+                              PropertyName = r.PropertyName,
+                              CategoryName = categoryName,
+                          },
+                      });
+                  }
+              });
+
+            // 3. Catalog: Prevent adding a property that already inherited from either parent category or catalog.
+            RuleFor(r => r)
+              .CustomAsync(async (r, context, _) =>
+              {
+                  var (isPropertyUnique, categoryName) = await CheckPropertyUniquenessInInheritedCategoriesAsync(r);
+
+                  if (!isPropertyUnique)
+                  {
+                      context.AddFailure(new ValidationFailure(r.PropertyName, "inherited-duplicated-property")
+                      {
+                          CustomState = new
+                          {
+                              PropertyName = r.PropertyName,
+                              CategoryName = categoryName,
+                          },
+                      });
+                  }
+              });
+
         }
 
-        protected virtual async Task<(bool, string)> CheckPropertyUniquenessInCategoryAsync(CategoryPropertyValidationRequest request)
+        protected virtual async Task<(bool, string)> CheckPropertyUniquenessInParentAsync(CategoryPropertyValidationRequest request)
+        {
+            var property = await FindPropertyWithSameName(request);
+
+            if (property != null)
+            {
+                return (false, await GetPropertyParentCategoryName(property));
+            }
+
+            return (true, null);
+        }
+
+        protected virtual async Task<(bool, string)> CheckPropertyUniquenessInInheritedCategoriesAsync(CategoryPropertyValidationRequest request)
         {
             if (string.IsNullOrEmpty(request.CategoryId))
             {
@@ -92,7 +122,7 @@ namespace VirtoCommerce.CatalogModule.Data.Validation
             {
                 if (property.IsInherited)
                 {
-                    return (false, await GetPropertyParentName(property));
+                    return (false, await GetPropertyParentCategoryName(property));
                 }
                 else
                 {
@@ -103,29 +133,21 @@ namespace VirtoCommerce.CatalogModule.Data.Validation
             return (true, null);
         }
 
-        private static string[] GetPropertiesNameForSearch(CategoryPropertyValidationRequest request)
-        {
-            var propertyName = request.PropertyName;
-            // "Alcholic % Volume" == "Alcholic_Volume"
-            var azureFieldPropertyName = Regex.Replace(propertyName, @"\W", "_");
-            return [propertyName, azureFieldPropertyName];
-        }
-
-        protected virtual async Task<(bool, string)> CheckPropertyUniquenessAsync(CategoryPropertyValidationRequest request)
+        protected virtual async Task<(bool, string)> CheckPropertyUniquenessInGlobalAsync(CategoryPropertyValidationRequest request)
         {
             // Allow to create a new property with the same name and same type
-            var existingProperty = await FindProperty(request);
+            var existingProperty = await FindPropertyWithSameNameAndDifferentType(request);
 
             if (existingProperty != null)
             {
-                var categoryName = await GetPropertyParentName(existingProperty);
+                var categoryName = await GetPropertyParentCategoryName(existingProperty);
                 return (false, categoryName);
             }
 
             return (true, null);
         }
 
-        private async Task<string> GetPropertyParentName(Property property)
+        private async Task<string> GetPropertyParentCategoryName(Property property)
         {
             if (string.IsNullOrEmpty(property.CategoryId))
             {
@@ -138,7 +160,24 @@ namespace VirtoCommerce.CatalogModule.Data.Validation
             }
         }
 
-        private async Task<Property> FindProperty(CategoryPropertyValidationRequest request)
+        private async Task<Property> FindPropertyWithSameName(CategoryPropertyValidationRequest request)
+        {
+            var propertyNamesForSearch = GetPropertiesNameForSearch(request);
+
+            var properties = await _propertySearchService.SearchPropertiesAsync(new PropertySearchCriteria
+            {
+                PropertyTypes = [request.PropertyType],
+                PropertyNames = propertyNamesForSearch,
+                CatalogId = request.CatalogId,
+                CategoryId = request.CategoryId,
+                Take = 1
+            });
+
+
+            return properties.Results.FirstOrDefault();
+        }
+
+        private async Task<Property> FindPropertyWithSameNameAndDifferentType(CategoryPropertyValidationRequest request)
         {
             var propertyNamesForSearch = GetPropertiesNameForSearch(request);
 
@@ -153,5 +192,15 @@ namespace VirtoCommerce.CatalogModule.Data.Validation
 
             return properties.Results.FirstOrDefault();
         }
+
+        private static string[] GetPropertiesNameForSearch(CategoryPropertyValidationRequest request)
+        {
+            var propertyName = request.PropertyName;
+            // "Alcholic % Volume" == "Alcholic_Volume"
+            var azureFieldPropertyName = Regex.Replace(propertyName, @"\W", "_");
+            return [propertyName, azureFieldPropertyName];
+        }
+
+
     }
 }

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-detail.tpl.html
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/property-detail.tpl.html
@@ -9,10 +9,22 @@
               </div>
               <span class="comment-text" ng-if="errorData">
                 <img src="/images/layout/warning.svg" class="comment-icon">
-                <span ng-if="errorData.errorMessage==='duplicate-property' && errorData.customState.categoryName">
+                <span ng-if="errorData.errorMessage==='duplicated-property' && errorData.customState.categoryName">
                   {{ 'catalog.blades.item-property-detail.labels.duplicate-property-in-product' | translate: errorData.customState }}
                 </span>
-                <span ng-if="errorData.errorMessage==='duplicate-property' && !errorData.customState.categoryName">
+                <span ng-if="errorData.errorMessage==='duplicated-property' && !errorData.customState.categoryName">
+                  {{ 'catalog.blades.item-property-detail.labels.duplicate-property-in-catalog' | translate: errorData.customState }}
+                </span>
+                <span ng-if="errorData.errorMessage==='inherited-duplicated-property' && errorData.customState.categoryName">
+                  {{ 'catalog.blades.item-property-detail.labels.duplicate-property-in-product' | translate: errorData.customState }}
+                </span>
+                <span ng-if="errorData.errorMessage==='inherited-duplicated-property' && !errorData.customState.categoryName">
+                  {{ 'catalog.blades.item-property-detail.labels.duplicate-property-in-catalog' | translate: errorData.customState }}
+                </span>
+                <span ng-if="errorData.errorMessage==='global-property-name-type' && errorData.customState.categoryName">
+                  {{ 'catalog.blades.item-property-detail.labels.duplicate-property-in-product' | translate: errorData.customState }}
+                </span>
+                <span ng-if="errorData.errorMessage==='global-property-name-type' && !errorData.customState.categoryName">
                   {{ 'catalog.blades.item-property-detail.labels.duplicate-property-in-catalog' | translate: errorData.customState }}
                 </span>
                 <span ng-if="errorData.errorMessage=='property-naming-error'">


### PR DESCRIPTION
## Description
fix: Enhance category property validation logic. Added new validation to ensure property uniqueness within categories and consistent property types across the catalog.


## References
### QA-test:
### Jira-link:




https://virtocommerce.atlassian.net/browse/VCST-3176
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.859.0-pr-790-58c9.zip