### PR TITLE
VCST-3193: Search field in catalog does not respond to Enter key press

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/directives/itemSearch.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/directives/itemSearch.js
@@ -20,7 +20,7 @@ angular.module('virtoCommerce.catalogModule').directive('vcItemSearch', ['$local
                 }
 
                 filter.filterByKeyword = function () {
-                    filter.ignoreSortingForRelevance = uiGridHelper.getSortExpression($scope);
+                    filter.ignoreSortingForRelevance = uiGridHelper.getSortExpression(blade.$scope);
                     filter.criteriaChanged();
                 };
 


### PR DESCRIPTION
## Description
fix: Search field in catalog does not respond to Enter key press


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3193
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.859.0-pr-792-28ea.zip