### PR TITLE
Fix images not cleared in CatalogProduct.ReduceDetails

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/Model/CatalogProduct.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/Model/CatalogProduct.cs
@@ -499,6 +499,7 @@ namespace VirtoCommerce.CatalogModule.Core.Model
             if (!productResponseGroup.HasFlag(ItemResponseGroup.ItemAssets))
             {
                 Assets = null;
+                Images = null;
             }
             if (!productResponseGroup.HasFlag(ItemResponseGroup.ItemAssociations))
             {


### PR DESCRIPTION
## Description

In the documentation of `ItemResponseGroup`, `ItemAssets` is described as: `With images and assets`.
However, in the `CatalogProduct.ReduceDetails` function, only the `Assets` field is set to null if this flag is not present.

In this pull request, a line is added to also set the `Images` field to null if the `ItemAssets` flag is not set. This ensures that the functionality more closely matches the documentation.

## References
### QA-test:
### Jira-link:
### Artifact URL:
