### PR TITLE
VCST-3599: Enable variation properties as facets for main product discovery

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/CatalogDocumentBuilder.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/CatalogDocumentBuilder.cs
@@ -46,7 +46,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
                 foreach (var property in searchResult.Results)
                 {
                     var propertyName = property.Name.ToLowerInvariant();
-                    var isCollection = property.Multivalue;
+                    var isCollection = property.Multivalue || property.Type == PropertyType.Variation;
 
                     switch (property.ValueType)
                     {
@@ -97,7 +97,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
 
         protected virtual void IndexCustomProperty(IndexDocument document, Property property, ICollection<PropertyType> contentPropertyTypes, bool addField = true)
         {
-            var isCollection = property.Multivalue;
+            var isCollection = property.Multivalue || property.Type == PropertyType.Variation;
 
             // replace empty value for Boolean property with default 'False'
             if (property.ValueType == PropertyValueType.Boolean && property.Values.IsNullOrEmpty())


### PR DESCRIPTION
## Description
fix: Updated the criteria for identifying a property as a collection to include both multi-value properties and properties of type Variation. This change enables variation properties as facets for main product discovery.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3599
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.874.0-pr-815-400b.zip