### PR TITLE
hot-fix: Use provided language code for SEO path resolution

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/Services/CatalogSeoResolver.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Services/CatalogSeoResolver.cs
@@ -235,7 +235,7 @@ public class CatalogSeoResolver : ISeoResolver
             return elements
                 ?.SelectMany(x => x.Outlines.Select(o => new
                 {
-                    SeoPath = o.Items.GetSeoPath(store, store.DefaultLanguage),
+                    SeoPath = o.Items.GetSeoPath(store, languageCode),
                     OutlinePath = o.Items.GetOutlinePath(),
                     x.Id
                 }))


### PR DESCRIPTION
Replaces usage of store's default language with the provided language code when resolving SEO paths in CatalogSeoResolver. This ensures SEO paths are generated in the correct language context.

## Description

## References
### QA-test:
### Jira-link:
### Artifact URL:
