### PR TITLE
VCST-4057: Refactor DELETE statements in catalog database commands

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data.MySql/MySqlCatalogRawDatabaseCommand.cs
+++ b/src/VirtoCommerce.CatalogModule.Data.MySql/MySqlCatalogRawDatabaseCommand.cs
@@ -341,9 +341,11 @@ namespace VirtoCommerce.CatalogModule.Data.MySql
                 DELETE A FROM Association A INNER JOIN Item I ON I.Id = A.AssociatedItemId
                 WHERE I.Id IN ({0}) OR I.ParentId IN ({0});
 
-                DELETE  FROM Item  WHERE ParentId IN ({0});
+                DELETE FROM ProductConfigurationOption WHERE ProductId IN ({0});
 
-                DELETE  FROM Item  WHERE Id IN ({0});
+                DELETE FROM Item WHERE ParentId IN ({0});
+
+                DELETE FROM Item WHERE Id IN ({0});
                 ";
 
             foreach (var itemIdsPage in itemIds.Paginate(BatchSize))

--- a/src/VirtoCommerce.CatalogModule.Data.PostgreSql/PostgreSqlCatalogRawDatabaseCommand.cs
+++ b/src/VirtoCommerce.CatalogModule.Data.PostgreSql/PostgreSqlCatalogRawDatabaseCommand.cs
@@ -175,6 +175,8 @@ namespace VirtoCommerce.CatalogModule.Data.PostgreSql
                         DELETE FROM ""Association"" A USING ""Item"" I WHERE I.""Id"" = A.""AssociatedItemId""
                         AND I.""Id"" IN ({0}) OR I.""ParentId"" IN ({0});
 
+                        DELETE FROM ""ProductConfigurationOption"" WHERE ""ProductId"" IN ({0});
+
                         DELETE FROM ""Item"" WHERE ""ParentId"" IN ({0});
 
                         DELETE FROM ""Item"" WHERE ""Id"" IN ({0});

--- a/src/VirtoCommerce.CatalogModule.Data.SqlServer/SqlServerCatalogRawDatabaseCommand.cs
+++ b/src/VirtoCommerce.CatalogModule.Data.SqlServer/SqlServerCatalogRawDatabaseCommand.cs
@@ -177,9 +177,11 @@ namespace VirtoCommerce.CatalogModule.Data.SqlServer
                     DELETE A FROM Association A INNER JOIN Item I ON I.Id = A.AssociatedItemId
                     WHERE I.Id IN ({0}) OR I.ParentId IN ({0})
 
-                    DELETE  FROM Item  WHERE ParentId IN ({0})
+                    DELETE FROM ProductConfigurationOption WHERE ProductId IN ({0})
 
-                    DELETE  FROM Item  WHERE Id IN ({0})
+                    DELETE FROM Item WHERE ParentId IN ({0})
+
+                    DELETE FROM Item WHERE Id IN ({0})
                 ";
 
             foreach (var itemIdsPage in itemIds.Paginate(batchSize))


### PR DESCRIPTION
## Description
fix: Updated SQL DELETE statements across MySql, PostgreSql, and SqlServer command files. Added a DELETE for `ProductConfigurationOption` by `ProductId` and refined existing DELETE statements for `Item` to ensure proper deletion based on `ParentId` and `Id`. This enhances the clarity and functionality of item association and configuration operations.


## References
### QA-test:
### Jira-link:
### Artifact URL:
