### PR TITLE
Test vcst 4958

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Module CI
 
 on:
@@ -53,7 +53,6 @@ jobs:
       version: ${{ steps.artifact_ver.outputs.shortVersion }}
       moduleId: ${{ steps.artifact_ver.outputs.moduleId }}
       matrix: ${{ steps.deployment-matrix.outputs.matrix }}
-      run-e2e: ${{ steps.run-e2e.outputs.result }}
       deployment-folder-exists: ${{ steps.check_deployment_folder.outputs.exists }}
       requiredModulesListUrl: ${{ steps.extract_required_modules_list_url_from_pr.outputs.url }}
 
@@ -210,18 +209,6 @@ jobs:
           deployConfigPath: '.deployment/module/cloudDeploy.json'
           releaseBranch: 'master'
 
-      - name: Check commit message for version number
-        id: run-e2e
-        env:
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-        run: |
-          if [[ "$COMMIT_MESSAGE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]];
-          then
-            echo "result=false" >> $GITHUB_OUTPUT
-          else
-            echo "result=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Extract required modules list URL from the pull request description
         if: ${{ github.event_name == 'pull_request' }}
         id: extract_required_modules_list_url_from_pr
@@ -297,73 +284,37 @@ jobs:
         if: success()
         run: |
           echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
+
   auto-tests:
-    # if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-    #     (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
+    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+        (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4958
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
     with:
       installModules: 'false'
       installCustomModule: 'true'
       customModuleId:  ${{ needs.ci.outputs.moduleId }}
       customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
       requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-      vctestingRepoBranch: 'test-VCST-4958' #'dev'
+      vctestingRepoBranch: 'dev'
       frontendZipUrl: 'latest'
       testSuites: 'graphql,restapi'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE_NEW }} #${{ secrets.VC_TESTING_MODULE_ENV_FILE }} #
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
-  # ui-auto-tests:
-  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-  #       (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
-  #   needs: 'ci'
-  #   uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
-  #   with:
-  #     installModules: 'false'
-  #     installCustomModule: 'true'
-  #     customModuleId:  ${{ needs.ci.outputs.moduleId }}
-  #     customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
-  #     requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-  #     vctestingRepoBranch: 'dev'
-  #     frontendZipUrl: 'latest'
-  #   secrets:
-  #     envPAT: ${{ secrets.REPO_TOKEN }}
-  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
-  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  # module-katalon-tests:
-  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
-  #       (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-  #   needs: 'ci'
-  #   uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.29
-  #   with:
-  #     katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
-  #     katalonRepoBranch: 'dev'
-  #     testSuite: 'Test Suites/Modules/Platform_collection'
-  #     installModules: 'false'
-  #     installCustomModule: 'true'
-  #     customModuleId:  ${{ needs.ci.outputs.moduleId }}
-  #     customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
-  #     requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-  #     platformDockerTag: 'dev-linux-latest'
-  #     storefrontDockerTag: 'dev-linux-latest'
-  #   secrets:
-  #     envPAT: ${{ secrets.REPO_TOKEN }}
-  #     katalonApiKey: ${{ secrets.KATALON_API_KEY }}
-
-  # deploy-cloud:
-  #   if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
-  #     && github.event_name == 'push'
-  #     && needs.ci.outputs.deployment-folder-exists == 'true'}}
-  #   needs: ci
-  #   uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.29
-  #   with:
-  #     releaseSource: module
-  #     moduleId: ${{ needs.ci.outputs.moduleId }}
-  #     moduleVer: ${{ needs.ci.outputs.version }}
-  #     moduleBlob: ${{ needs.ci.outputs.blobId }}
-  #     jiraKeys: ${{ needs.ci.outputs.jira-keys }}
-  #     matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-  #   secrets: inherit
+  deploy-cloud:
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+      && github.event_name == 'push'
+      && needs.ci.outputs.deployment-folder-exists == 'true'}}
+    needs: ci
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.30
+    with:
+      releaseSource: module
+      moduleId: ${{ needs.ci.outputs.moduleId }}
+      moduleVer: ${{ needs.ci.outputs.version }}
+      moduleBlob: ${{ needs.ci.outputs.blobId }}
+      jiraKeys: ${{ needs.ci.outputs.jira-keys }}
+      matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
+    secrets: inherit

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -308,7 +308,7 @@ jobs:
       customModuleId:  ${{ needs.ci.outputs.moduleId }}
       customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
       requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-      vctestingRepoBranch: 'dev'
+      vctestingRepoBranch: 'test-VCST-4958' #'dev'
       frontendZipUrl: 'latest'
       testSuites: 'graphql,restapi'
     secrets:

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -297,12 +297,11 @@ jobs:
         if: success()
         run: |
           echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
-
-  ui-auto-tests:
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-        (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
-    needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
+  auto-tests:
+    # if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+    #     (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
+    needs: ci
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4958
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -311,42 +310,60 @@ jobs:
       requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
       vctestingRepoBranch: 'dev'
       frontendZipUrl: 'latest'
+      testSuites: 'graphql,restapi'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE_NEW }} #${{ secrets.VC_TESTING_MODULE_ENV_FILE }} #
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
+  # ui-auto-tests:
+  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+  #       (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
+  #   needs: 'ci'
+  #   uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
+  #   with:
+  #     installModules: 'false'
+  #     installCustomModule: 'true'
+  #     customModuleId:  ${{ needs.ci.outputs.moduleId }}
+  #     customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
+  #     requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
+  #     vctestingRepoBranch: 'dev'
+  #     frontendZipUrl: 'latest'
+  #   secrets:
+  #     envPAT: ${{ secrets.REPO_TOKEN }}
+  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  module-katalon-tests:
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
-        (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.29
-    with:
-      katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
-      katalonRepoBranch: 'dev'
-      testSuite: 'Test Suites/Modules/Platform_collection'
-      installModules: 'false'
-      installCustomModule: 'true'
-      customModuleId:  ${{ needs.ci.outputs.moduleId }}
-      customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
-      requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
-      platformDockerTag: 'dev-linux-latest'
-      storefrontDockerTag: 'dev-linux-latest'
-    secrets:
-      envPAT: ${{ secrets.REPO_TOKEN }}
-      katalonApiKey: ${{ secrets.KATALON_API_KEY }}
+  # module-katalon-tests:
+  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
+  #       (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
+  #   needs: 'ci'
+  #   uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.29
+  #   with:
+  #     katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
+  #     katalonRepoBranch: 'dev'
+  #     testSuite: 'Test Suites/Modules/Platform_collection'
+  #     installModules: 'false'
+  #     installCustomModule: 'true'
+  #     customModuleId:  ${{ needs.ci.outputs.moduleId }}
+  #     customModuleUrl:  ${{ needs.ci.outputs.artifactUrl }}
+  #     requiredModulesListUrl: ${{ needs.ci.outputs.requiredModulesListUrl }}
+  #     platformDockerTag: 'dev-linux-latest'
+  #     storefrontDockerTag: 'dev-linux-latest'
+  #   secrets:
+  #     envPAT: ${{ secrets.REPO_TOKEN }}
+  #     katalonApiKey: ${{ secrets.KATALON_API_KEY }}
 
-  deploy-cloud:
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
-      && github.event_name == 'push'
-      && needs.ci.outputs.deployment-folder-exists == 'true'}}
-    needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.29
-    with:
-      releaseSource: module
-      moduleId: ${{ needs.ci.outputs.moduleId }}
-      moduleVer: ${{ needs.ci.outputs.version }}
-      moduleBlob: ${{ needs.ci.outputs.blobId }}
-      jiraKeys: ${{ needs.ci.outputs.jira-keys }}
-      matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-    secrets: inherit
+  # deploy-cloud:
+  #   if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+  #     && github.event_name == 'push'
+  #     && needs.ci.outputs.deployment-folder-exists == 'true'}}
+  #   needs: ci
+  #   uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.29
+  #   with:
+  #     releaseSource: module
+  #     moduleId: ${{ needs.ci.outputs.moduleId }}
+  #     moduleVer: ${{ needs.ci.outputs.version }}
+  #     moduleBlob: ${{ needs.ci.outputs.blobId }}
+  #     jiraKeys: ${{ needs.ci.outputs.jira-keys }}
+  #     matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
+  #   secrets: inherit


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4958
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.1021.0-pr-879-eb15.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace-only change to a GitHub Actions workflow; no behavior should change aside from eliminating potential YAML/linters edge cases.
> 
> **Overview**
> Fixes formatting in `.github/workflows/module-ci.yml` by ensuring the `deploy-cloud` job ends cleanly with `secrets: inherit` and a trailing newline (no functional CI logic changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb15cd026589b42b422ba99baa0eb4d6a4d8d206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->