### PR TITLE
Test PR for VCST-5054

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -79,17 +79,17 @@ jobs:
           fetch-depth: 0
 
       - name: Install VirtoCommerce.GlobalTool
-        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@VCST-5054 #master
 
       - name: Install dotnet-sonarscanner
         run: dotnet tool install --global dotnet-sonarscanner
 
       - name: Get Changelog
         id: changelog
-        uses: VirtoCommerce/vc-github-actions/changelog-generator@master
+        uses: VirtoCommerce/vc-github-actions/changelog-generator@VCST-5054 #master
 
       - name: Get Artifact Version
-        uses: VirtoCommerce/vc-github-actions/get-image-version@master
+        uses: VirtoCommerce/vc-github-actions/get-image-version@VCST-5054 #master
         id: artifact_ver
 
       - name: Check if .deployment folder exists
@@ -113,12 +113,12 @@ jobs:
 
       - name: Add version suffix
         if: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
-        uses: VirtoCommerce/vc-github-actions/add-version-suffix@master
+        uses: VirtoCommerce/vc-github-actions/add-version-suffix@VCST-5054 #master
         with:
           versionSuffix: ${{ env.VERSION_SUFFIX }}
 
       - name: SonarCloud Begin
-        uses: VirtoCommerce/vc-github-actions/sonar-scanner-begin@master
+        uses: VirtoCommerce/vc-github-actions/sonar-scanner-begin@VCST-5054 #master
         with:
           repoOrg: ${{ github.repository_owner }}
           sonarOrg: ${{secrets.SONAR_ORG_KEY}}
@@ -130,10 +130,10 @@ jobs:
         run: vc-build Test -skip
 
       - name: SonarCloud End
-        uses: VirtoCommerce/vc-github-actions/sonar-scanner-end@master
+        uses: VirtoCommerce/vc-github-actions/sonar-scanner-end@VCST-5054 #master
 
       - name: Quality Gate
-        uses: VirtoCommerce/vc-github-actions/sonar-quality-gate@master
+        uses: VirtoCommerce/vc-github-actions/sonar-quality-gate@VCST-5054 #master
         with:
           login: ${{secrets.SONAR_TOKEN}}
 
@@ -142,12 +142,12 @@ jobs:
 
       - name: Publish Nuget
         if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
-        uses: VirtoCommerce/vc-github-actions/publish-nuget@master
+        uses: VirtoCommerce/vc-github-actions/publish-nuget@VCST-5054 #master
 
       - name: Publish to Blob
         if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master') || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main') }}
         id: blobRelease
-        uses: VirtoCommerce/vc-github-actions/publish-blob-release@master
+        uses: VirtoCommerce/vc-github-actions/publish-blob-release@VCST-5054 #master
         with:
           blobSAS: ${{ secrets.BLOB_TOKEN }}
           blobUrl: ${{ vars.BLOB_URL }}
@@ -169,7 +169,7 @@ jobs:
 
       - name: Add Jira link
         if: ${{ github.event_name == 'pull_request' }}
-        uses: VirtoCommerce/vc-github-actions/publish-jira-link@master
+        uses: VirtoCommerce/vc-github-actions/publish-jira-link@VCST-5054 #master
         with:
           branchName: ${{ steps.sanitize_branch.outputs.branchName }}
           repoOrg: ${{ github.repository_owner }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Add link to PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: VirtoCommerce/vc-github-actions/publish-artifact-link@master
+        uses: VirtoCommerce/vc-github-actions/publish-artifact-link@VCST-5054 #master
         with:
           artifactUrl: ${{ steps.blobRelease.outputs.packageUrl }}
           repoOrg: ${{ github.repository_owner }}
@@ -190,7 +190,7 @@ jobs:
         with:
           changelog: ${{ steps.changelog.outputs.changelog }}
           organization: ${{ github.repository_owner }}
-        uses: VirtoCommerce/vc-github-actions/publish-github-release@master
+        uses: VirtoCommerce/vc-github-actions/publish-github-release@VCST-5054 #master
 
       - name: Set artifactUrl value
         id: artifactUrl
@@ -203,7 +203,7 @@ jobs:
 
       - name: Create deployment matrix
         if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
-        uses: VirtoCommerce/vc-github-actions/cloud-create-deploy-matrix@master
+        uses: VirtoCommerce/vc-github-actions/cloud-create-deploy-matrix@VCST-5054 #master
         id: deployment-matrix
         with:
           deployConfigPath: '.deployment/module/cloudDeploy.json'
@@ -241,18 +241,18 @@ jobs:
 
       - name: Setup Git Credentials
         if: ${{ (github.ref == 'refs/heads/dev' && github.event_name != 'workflow_dispatch') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
-        uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@master
+        uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@VCST-5054 #master
         with:
           githubToken: ${{ secrets.REPO_TOKEN }}
 
       - name: Publish Manifest
         if: ${{ (github.ref == 'refs/heads/dev' && github.event_name != 'workflow_dispatch') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
-        uses: VirtoCommerce/vc-github-actions/publish-manifest@master
+        uses: VirtoCommerce/vc-github-actions/publish-manifest@VCST-5054 #master
         with:
           packageUrl: ${{ steps.artifactUrl.outputs.download_url }}
 
       - name: Parse Jira Keys from All Commits
-        uses: VirtoCommerce/vc-github-actions/get-jira-keys@master
+        uses: VirtoCommerce/vc-github-actions/get-jira-keys@VCST-5054 #master
         if: always()
         id: jira_keys
         with:

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -289,7 +289,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-554 #v3.800.35
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -310,7 +310,7 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@VCST-554 #v3.800.35
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -289,7 +289,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-554 #v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-5054 #v3.800.35
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -310,7 +310,7 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@VCST-554 #v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@VCST-5054 #v3.800.35
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}

--- a/.github/workflows/module-release-hotfix.yml
+++ b/.github/workflows/module-release-hotfix.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-554 #v3.800.35
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-554 #v3.800.35    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-554 #v3.800.35
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/module-release-hotfix.yml
+++ b/.github/workflows/module-release-hotfix.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-554 #v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-5054 #v3.800.35
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-554 #v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-5054 #v3.800.35    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -46,7 +46,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-554 #v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-5054 #v3.800.35
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-554 #v3.800.35    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-554 #v3.800.35    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-554 #v3.800.35
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-554 #v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-5054 #v3.800.35    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-554 #v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-5054 #v3.800.35    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-554 #v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-5054 #v3.800.35
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@VCST-554 #v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@VCST-5054 #v3.800.35    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@VCST-554 #v3.800.35    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5054
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.1025.0-alpha.2521-test-vcst-5054.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing action/workflow refs affects build, test, publish, deploy, and release paths; behavior depends on unmerged VCST-5054 action code until refs are reverted to stable tags/branches.
> 
> **Overview**
> This PR **retargets CI/CD reusable workflows and composite actions** from `@master` / `@v3.800.35` to the **`VCST-5054`** branch so pipelines exercise in-flight changes in `VirtoCommerce/vc-github-actions` and `VirtoCommerce/.github`.
> 
> **`module-ci.yml`** updates the bulk of `vc-github-actions/*` steps (build, Sonar, packaging, blob/GitHub publish, Jira/artifact links, manifest, deploy matrix, etc.) and the downstream **`pytest-tests`** and **`deploy-cloud`** reusable workflows. **`release.yml`**, **`publish-nugets.yml`**, and **`module-release-hotfix.yml`** similarly point `test-and-sonar`, `build`, `publish-github`, and `release` workflows at `VCST-5054`. Inline comments preserve the previous ref (e.g. `#master`, `#v3.800.35`) for easy revert.
> 
> **`module-ci.yml`** also adds a trailing newline after `secrets: inherit` on the deploy-cloud job (formatting only). **`module-release-hotfix.yml`** still uses `@master` for `changelog-generator` in `get-metadata`—not changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c7b5ed87d83803d17c3094a82e3309eea6fc64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->