### PR TITLE
VCST-4492: Test new workflow versions

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.36
-# https://virtocommerce.atlassian.net/browse/VCST-5151
+# v3.800.37
+# https://virtocommerce.atlassian.net/browse/VCST-5155
 name: Module CI
 
 on:
@@ -28,12 +28,20 @@ on:
       - '**/cloudDeploy.json'
       - samples/**
 
+# Least-privilege default; jobs override below where they need more.
+permissions:
+  contents: read
+
 jobs:
   ci:
     if: ${{ github.actor != 'dependabot[bot]' &&
         (github.event.pull_request.head.repo.full_name == github.repository ||
         github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
     runs-on: ubuntu-24.04
+    # Default GITHUB_TOKEN creates the release + updates the PR; rest uses the REPO_TOKEN PAT.
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
       CLIENT_ID: ${{secrets.CLIENT_ID}}
@@ -59,12 +67,12 @@ jobs:
     steps:
 
       - name: Set up Node 24
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
             node-version: '24'
 
       - name: Set up Java 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -74,9 +82,10 @@ jobs:
         run: |
           echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install VirtoCommerce.GlobalTool
         uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
@@ -106,10 +115,13 @@ jobs:
       - name: Set VERSION_SUFFIX variable
         run: |
           if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
-            echo "VERSION_SUFFIX=${{ steps.artifact_ver.outputs.fullSuffix }}" >> $GITHUB_ENV
+            echo "VERSION_SUFFIX=${STEPS_ARTIFACT_VER_OUTPUTS_FULLSUFFIX}" >> $GITHUB_ENV
           else
-            echo "VERSION_SUFFIX=${{ steps.artifact_ver.outputs.suffix }}" >> $GITHUB_ENV
+            echo "VERSION_SUFFIX=${STEPS_ARTIFACT_VER_OUTPUTS_SUFFIX}" >> $GITHUB_ENV
           fi;
+        env:
+          STEPS_ARTIFACT_VER_OUTPUTS_FULLSUFFIX: ${{ steps.artifact_ver.outputs.fullSuffix }}
+          STEPS_ARTIFACT_VER_OUTPUTS_SUFFIX: ${{ steps.artifact_ver.outputs.suffix }}
 
       - name: Add version suffix
         if: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
@@ -195,11 +207,14 @@ jobs:
       - name: Set artifactUrl value
         id: artifactUrl
         run: |
-          if [ '${{ github.ref }}' = 'refs/heads/master' ] || [ '${{ github.ref }}' = 'refs/heads/main' ]; then
-            echo "download_url=${{ steps.githubRelease.outputs.downloadUrl }}" >> $GITHUB_OUTPUT
+          if [ "${GITHUB_REF}" = 'refs/heads/master' ] || [ "${GITHUB_REF}" = 'refs/heads/main' ]; then
+            echo "download_url=${STEPS_GITHUBRELEASE_OUTPUTS_DOWNLOADURL}" >> $GITHUB_OUTPUT
           else
-            echo "download_url=${{ steps.blobRelease.outputs.packageUrl }}" >> $GITHUB_OUTPUT
+            echo "download_url=${STEPS_BLOBRELEASE_OUTPUTS_PACKAGEURL}" >> $GITHUB_OUTPUT
           fi;
+        env:
+          STEPS_GITHUBRELEASE_OUTPUTS_DOWNLOADURL: ${{ steps.githubRelease.outputs.downloadUrl }}
+          STEPS_BLOBRELEASE_OUTPUTS_PACKAGEURL: ${{ steps.blobRelease.outputs.packageUrl }}
 
       - name: Create deployment matrix
         if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
@@ -297,13 +312,15 @@ jobs:
       - name: Confirm Jira Build Output
         if: success()
         run: |
-          echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
+          echo "Jira Upload Build Info response: ${STEPS_PUSH_BUILD_INFO_TO_JIRA_OUTPUTS_RESPONSE}"
+        env:
+          STEPS_PUSH_BUILD_INFO_TO_JIRA_OUTPUTS_RESPONSE: ${{ steps.push_build_info_to_jira.outputs.response }}
 
   auto-tests:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.36
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4492
     with:
       installModules: 'false'
       installCustomModule: 'true'
@@ -324,7 +341,11 @@ jobs:
       && github.event_name == 'push'
       && needs.ci.outputs.deployment-folder-exists == 'true'}}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.36
+    # deploy-cloud.yml writes deployment status via GITHUB_TOKEN; rest uses inherited PATs.
+    permissions:
+      contents: read
+      deployments: write
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@VCST-4492
     with:
       releaseSource: module
       moduleId: ${{ needs.ci.outputs.moduleId }}
@@ -332,4 +353,4 @@ jobs:
       moduleBlob: ${{ needs.ci.outputs.blobId }}
       jiraKeys: ${{ needs.ci.outputs.jira-keys }}
       matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit] deploy-cloud.yml@VCST-4492 reads undeclared org secrets; explicit passing needs a new release + tag bump

--- a/.github/workflows/module-release-hotfix.yml
+++ b/.github/workflows/module-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.36
-# https://virtocommerce.atlassian.net/browse/VCST-5151
+# v3.800.37
+# https://virtocommerce.atlassian.net/browse/VCST-5155
 name: Release hotfix
 
 on:
@@ -11,14 +11,18 @@ on:
         default: true
         type: boolean
 
+# Least-privilege default; publish-github-release overrides below.
+permissions:
+  contents: read
+
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.36
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-4492
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.36    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-4492    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -35,18 +39,23 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Get Changelog
       id: changelog
       uses: VirtoCommerce/vc-github-actions/changelog-generator@master
 
   publish-github-release:
+    # publish-github.yml creates the release + edits the PR via the passed GITHUB_TOKEN — grant write to both.
+    permissions:
+      contents: write
+      pull-requests: write
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.36
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-4492
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'
@@ -64,7 +73,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
 
     - name: Install VirtoCommerce.GlobalTool
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.36
-# https://virtocommerce.atlassian.net/browse/VCST-5151
+# v3.800.37
+# https://virtocommerce.atlassian.net/browse/VCST-5155
 name: Publish nuget
 
 on:
@@ -11,14 +11,18 @@ on:
         default: true
         type: boolean
 
+# Least-privilege default; publish-nuget overrides below.
+permissions:
+  contents: read
+
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.36    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-4492    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.36    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-4492    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -27,9 +31,13 @@ jobs:
       envPAT: ${{ secrets.REPO_TOKEN }}
 
   publish-nuget:
+    # publish-github.yml creates the release + edits the PR via the passed GITHUB_TOKEN — grant write to both.
+    permissions:
+      contents: write
+      pull-requests: write
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.36
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-4492
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
-# v3.800.36
-# https://virtocommerce.atlassian.net/browse/VCST-5151
+# v3.800.37
+# https://virtocommerce.atlassian.net/browse/VCST-5155
 name: Release
 
 on:
   workflow_dispatch:
 
+# Least privilege: the reusable workflow pushes with the REPO_TOKEN PAT, so GITHUB_TOKEN needs only read.
+permissions:
+  contents: read
+
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.36    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@VCST-4492    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4492
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.1029.0-alpha.2527-test-vcst-4492.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect every module build, test, release, and cloud deploy path by switching reusable workflow refs from a release tag to a branch; misconfiguration could break CI or widen/narrow token scope incorrectly.
> 
> **Overview**
> Bumps the local workflow bundle to **v3.800.37** (VCST-5155) and points reusable workflows in `VirtoCommerce/.github` from **`@v3.800.36`** to **`@VCST-4492`** across module CI, hotfix release, NuGet publish, and release entrypoints.
> 
> **Security and hygiene:** workflow-wide default **`permissions: contents: read`**, with job-level grants where releases/PRs or deployments need write access. **`actions/checkout`** is pinned to **v6.0.3** with **`persist-credentials: false`**; setup-node/java comments note patch versions. Several shell steps stop interpolating `${{ steps.* }}` inside `run` blocks and pass values via **`env`** instead (version suffix, artifact URL, Jira echo).
> 
> **Module CI** grants the main **`ci`** job `contents` + `pull-requests` write, adds **`deploy-cloud`** `deployments: write`, and documents **`secrets: inherit`** for zizmor on deploy-cloud.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39517a4dbf90a5deca3e6051f310c3af5c3306c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->