### PR TITLE
VCST-5513: Bump HtmlSanitizer to 9.1.973

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Data/VirtoCommerce.CatalogModule.Data.csproj
+++ b/src/VirtoCommerce.CatalogModule.Data/VirtoCommerce.CatalogModule.Data.csproj
@@ -13,7 +13,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
+    <PackageReference Include="HtmlSanitizer" Version="9.1.973" />
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.ExportModule.Data" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />


### PR DESCRIPTION
## Description
fix: Bump HtmlSanitizer to 9.1.973

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5513
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.1039.0-pr-902-6a27.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump with no API or wiring changes; typical low-risk maintenance for the sanitizer used on catalog property values.
> 
> **Overview**
> Updates the **HtmlSanitizer** NuGet package from **9.0.892** to **9.1.973** on `VirtoCommerce.CatalogModule.Data`. No application code changes; catalog property HTML still flows through `PropertyValueSanitizer` and the existing `IHtmlSanitizer` registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a27a3f5186839522430df12745eb427b5a8b628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->