### PR TITLE
VCST-5490: use BackgroundJobs

### DIFF
--- a/module.ignore
+++ b/module.ignore
@@ -1,6 +1,5 @@
 Antlr4.Runtime.Standard.dll
 FluentAssertions.dll
-Hangfire.Console.dll
 Microsoft.Data.SqlClient.SNI.dll
 Nager.Country.dll
 sni.dll

--- a/src/VirtoCommerce.CatalogModule.Core/VirtoCommerce.CatalogModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogModule.Core/VirtoCommerce.CatalogModule.Core.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
     <PackageReference Include="VirtoCommerce.ExportModule.Core" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1052.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
     <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1004.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />

--- a/src/VirtoCommerce.CatalogModule.Data.MySql/VirtoCommerce.CatalogModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CatalogModule.Data.MySql/VirtoCommerce.CatalogModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogModule.Data\VirtoCommerce.CatalogModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogModule.Data.PostgreSql/VirtoCommerce.CatalogModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CatalogModule.Data.PostgreSql/VirtoCommerce.CatalogModule.Data.PostgreSql.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogModule.Data\VirtoCommerce.CatalogModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogModule.Data.SqlServer/VirtoCommerce.CatalogModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CatalogModule.Data.SqlServer/VirtoCommerce.CatalogModule.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogModule.Data\VirtoCommerce.CatalogModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogModule.Data/BackgroundJobs/AutomaticLinksJob.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/BackgroundJobs/AutomaticLinksJob.cs
@@ -1,24 +1,18 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Hangfire;
 using VirtoCommerce.CatalogModule.Core.Services;
 
 namespace VirtoCommerce.CatalogModule.Data.BackgroundJobs;
 
+// The [Obsolete] IJobCancellationToken overloads are gone with the Hangfire reference: that parameter type came from
+// the Hangfire package this module no longer references, so it could not be kept. Legacy queue items naming those
+// overloads can no longer be dispatched; new work goes through UpdateAutomaticLinksJobHandler and
+// DeleteAutomaticLinksJobHandler.
 public class AutomaticLinksJob(IAutomaticLinkService automaticLinkService)
 {
     public Task UpdateLinks(string categoryId, CancellationToken cancellationToken)
         => automaticLinkService.UpdateLinks(categoryId, cancellationToken);
 
-    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    public Task UpdateLinks(string categoryId, IJobCancellationToken cancellationToken)
-        => UpdateLinks(categoryId, cancellationToken?.ShutdownToken ?? CancellationToken.None);
-
     public Task DeleteLinks(string categoryId, CancellationToken cancellationToken)
         => automaticLinkService.DeleteLinks(categoryId, cancellationToken);
-
-    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    public Task DeleteLinks(string categoryId, IJobCancellationToken cancellationToken)
-        => DeleteLinks(categoryId, cancellationToken?.ShutdownToken ?? CancellationToken.None);
 }

--- a/src/VirtoCommerce.CatalogModule.Data/Handlers/LogChangesChangedEventHandler.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Handlers/LogChangesChangedEventHandler.cs
@@ -2,14 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using VirtoCommerce.CatalogModule.Core;
 using VirtoCommerce.CatalogModule.Core.Events;
 using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Data.Jobs;
 using VirtoCommerce.CatalogModule.Data.Repositories;
 using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 
 namespace VirtoCommerce.CatalogModule.Data.Handlers
 {
@@ -30,22 +31,27 @@ namespace VirtoCommerce.CatalogModule.Data.Handlers
 
         public virtual Task Handle(ProductChangedEvent @event)
         {
-            InnerHandle(@event);
-            return Task.CompletedTask;
+            return InnerHandle(@event);
         }
 
         public virtual Task Handle(CategoryChangedEvent @event)
         {
-            InnerHandle(@event);
-            return Task.CompletedTask;
+            return InnerHandle(@event);
         }
 
-        protected virtual void InnerHandle<T>(GenericChangedEntryEvent<T> @event) where T : IEntity
+        // Returns Task instead of void: enqueuing is asynchronous now. Breaking for an already-compiled override,
+        // which stops overriding the signature Handle calls and would be silently skipped.
+        protected virtual Task InnerHandle<T>(GenericChangedEntryEvent<T> @event) where T : IEntity
         {
             var logOperations = GetLogOperations(@event.ChangedEntries).ToArray();
 
+            var payload = AbstractTypeFactory<LogEntityChangesJobPayload>.TryCreateInstance();
+            payload.OperationLogs = logOperations;
+
             //Background task is used here for performance reasons
-            BackgroundJob.Enqueue(() => LogEntityChangesInBackgroundAsync(logOperations));
+            //The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once from
+            //the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+            return BackgroundJob.Enqueue<LogEntityChangesJobHandler>(payload);
         }
 
         protected virtual IEnumerable<OperationLog> GetLogOperations<T>(IEnumerable<GenericChangedEntry<T>> changedEntries) where T : IEntity

--- a/src/VirtoCommerce.CatalogModule.Data/Handlers/TrackSpecialChangesEventHandler.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Handlers/TrackSpecialChangesEventHandler.cs
@@ -2,14 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Hangfire;
 using Microsoft.EntityFrameworkCore;
 using VirtoCommerce.CatalogModule.Core.Events;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Services;
+using VirtoCommerce.CatalogModule.Data.Jobs;
 using VirtoCommerce.CatalogModule.Data.Repositories;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
 
 namespace VirtoCommerce.CatalogModule.Data.Handlers
 {
@@ -24,7 +25,7 @@ namespace VirtoCommerce.CatalogModule.Data.Handlers
             _itemService = itemService;
         }
 
-        public Task Handle(CategoryChangedEvent message)
+        public async Task Handle(CategoryChangedEvent message)
         {
             var categoryIds = message.ChangedEntries
                 .Where(x =>
@@ -38,10 +39,13 @@ namespace VirtoCommerce.CatalogModule.Data.Handlers
 
             if (categoryIds.Any())
             {
-                BackgroundJob.Enqueue(() => UpdateProductsAsync(categoryIds));
-            }
+                var payload = AbstractTypeFactory<UpdateProductsJobPayload>.TryCreateInstance();
+                payload.CategoryIds = categoryIds;
 
-            return Task.CompletedTask;
+                //The static facade, not an injected IBackgroundJob: RegisterEventHandler resolves this handler once
+                //from the root provider and holds it for the process lifetime, so it must not capture a Scoped dependency.
+                await BackgroundJob.Enqueue<UpdateProductsJobHandler>(payload);
+            }
         }
 
         /// <summary>

--- a/src/VirtoCommerce.CatalogModule.Data/Jobs/AutomaticLinksJobPayload.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Jobs/AutomaticLinksJobPayload.cs
@@ -1,0 +1,11 @@
+namespace VirtoCommerce.CatalogModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background jobs that rebuild or drop a category's automatic links. One payload type serves both
+    /// jobs: the work is addressed by handler, and both need exactly the category id.
+    /// </summary>
+    public class AutomaticLinksJobPayload
+    {
+        public string CategoryId { get; set; }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Data/Jobs/DeleteAutomaticLinksJobHandler.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Jobs/DeleteAutomaticLinksJobHandler.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.CatalogModule.Data.BackgroundJobs;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.CatalogModule.Data.Jobs
+{
+    /// <summary>
+    /// Drops a category's automatic links, off the request thread.
+    /// </summary>
+    public class DeleteAutomaticLinksJobHandler(AutomaticLinksJob job) : IBackgroundJobHandler<AutomaticLinksJobPayload>
+    {
+        public virtual Task Execute(AutomaticLinksJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return job.DeleteLinks(payload.CategoryId, cancellationToken);
+        }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Data/Jobs/LogEntityChangesJobHandler.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Jobs/LogEntityChangesJobHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.CatalogModule.Data.Handlers;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.CatalogModule.Data.Jobs
+{
+    /// <summary>
+    /// Persists the change-log entries collected for changed products and categories, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="LogChangesChangedEventHandler"/>, which still owns the logic - it expands the batch
+    /// with the affected child categories - and stays callable by background jobs enqueued by an earlier version.
+    /// </remarks>
+    public class LogEntityChangesJobHandler(LogChangesChangedEventHandler eventHandler) : IBackgroundJobHandler<LogEntityChangesJobPayload>
+    {
+        public virtual Task Execute(LogEntityChangesJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return eventHandler.LogEntityChangesInBackgroundAsync(payload.OperationLogs);
+        }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Data/Jobs/LogEntityChangesJobPayload.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Jobs/LogEntityChangesJobPayload.cs
@@ -1,0 +1,12 @@
+using VirtoCommerce.Platform.Core.ChangeLog;
+
+namespace VirtoCommerce.CatalogModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that persists catalog change-log entries.
+    /// </summary>
+    public class LogEntityChangesJobPayload
+    {
+        public OperationLog[] OperationLogs { get; set; }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Data/Jobs/UpdateAutomaticLinksJobHandler.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Jobs/UpdateAutomaticLinksJobHandler.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.CatalogModule.Data.BackgroundJobs;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.CatalogModule.Data.Jobs
+{
+    /// <summary>
+    /// Rebuilds a category's automatic links, off the request thread.
+    /// </summary>
+    public class UpdateAutomaticLinksJobHandler(AutomaticLinksJob job) : IBackgroundJobHandler<AutomaticLinksJobPayload>
+    {
+        public virtual Task Execute(AutomaticLinksJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return job.UpdateLinks(payload.CategoryId, cancellationToken);
+        }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Data/Jobs/UpdateProductsJobHandler.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Jobs/UpdateProductsJobHandler.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.CatalogModule.Data.Handlers;
+using VirtoCommerce.Platform.Core.Jobs;
+
+namespace VirtoCommerce.CatalogModule.Data.Jobs
+{
+    /// <summary>
+    /// Resaves the products under categories whose hierarchy or visibility changed, off the request thread.
+    /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="TrackSpecialChangesEventHandler"/>, which still owns the logic and stays callable by
+    /// background jobs enqueued by an earlier version that reference its method by name.
+    /// </remarks>
+    public class UpdateProductsJobHandler(TrackSpecialChangesEventHandler eventHandler) : IBackgroundJobHandler<UpdateProductsJobPayload>
+    {
+        public virtual Task Execute(UpdateProductsJobPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return eventHandler.UpdateProductsAsync(payload.CategoryIds);
+        }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Data/Jobs/UpdateProductsJobPayload.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Jobs/UpdateProductsJobPayload.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace VirtoCommerce.CatalogModule.Data.Jobs
+{
+    /// <summary>
+    /// Payload of the background job that resaves the products under categories whose hierarchy or visibility changed.
+    /// </summary>
+    public class UpdateProductsJobPayload
+    {
+        public List<string> CategoryIds { get; set; }
+    }
+}

--- a/src/VirtoCommerce.CatalogModule.Data/VirtoCommerce.CatalogModule.Data.csproj
+++ b/src/VirtoCommerce.CatalogModule.Data/VirtoCommerce.CatalogModule.Data.csproj
@@ -16,9 +16,8 @@
     <PackageReference Include="HtmlSanitizer" Version="9.1.973" />
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.ExportModule.Data" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1052.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogModule.Core\VirtoCommerce.CatalogModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleCategoriesController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleCategoriesController.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
@@ -12,9 +11,10 @@ using VirtoCommerce.CatalogModule.Core;
 using VirtoCommerce.CatalogModule.Core.Extensions;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Services;
-using VirtoCommerce.CatalogModule.Data.BackgroundJobs;
+using VirtoCommerce.CatalogModule.Data.Jobs;
 using VirtoCommerce.CatalogModule.Web.Authorization;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.PushNotifications;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.SearchModule.Core.BackgroundJobs;
@@ -290,18 +290,29 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
 
         [HttpPost("{id}/automatic-links")]
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
-        public ActionResult UpdateAutomaticLinks(string id)
+        public async Task<ActionResult> UpdateAutomaticLinks(string id)
         {
-            BackgroundJob.Enqueue<AutomaticLinksJob>(x => x.UpdateLinks(id, CancellationToken.None));
+            await EnqueueAutomaticLinksJob<UpdateAutomaticLinksJobHandler>(id);
             return NoContent();
         }
 
         [HttpDelete("{id}/automatic-links")]
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
-        public ActionResult DeleteAutomaticLinks(string id)
+        public async Task<ActionResult> DeleteAutomaticLinks(string id)
         {
-            BackgroundJob.Enqueue<AutomaticLinksJob>(x => x.DeleteLinks(id, CancellationToken.None));
+            await EnqueueAutomaticLinksJob<DeleteAutomaticLinksJobHandler>(id);
             return NoContent();
+        }
+
+        // The static facade, not an injected IBackgroundJob: keeps the controller's dependency list unchanged, and the
+        // facade opens its own scope per call, so nothing scoped is captured here.
+        private static Task EnqueueAutomaticLinksJob<THandler>(string categoryId)
+            where THandler : class
+        {
+            var payload = AbstractTypeFactory<AutomaticLinksJobPayload>.TryCreateInstance();
+            payload.CategoryId = categoryId;
+
+            return BackgroundJob.Enqueue<THandler>(payload);
         }
 
         /// <summary>

--- a/src/VirtoCommerce.CatalogModule.Web/Module.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Module.cs
@@ -29,7 +29,9 @@ using VirtoCommerce.CatalogModule.Core.Search.Sorting.Resolvers;
 using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.CatalogModule.Data.Authorization;
 using VirtoCommerce.CatalogModule.Data.ExportImport;
+using VirtoCommerce.CatalogModule.Data.BackgroundJobs;
 using VirtoCommerce.CatalogModule.Data.Handlers;
+using VirtoCommerce.CatalogModule.Data.Jobs;
 using VirtoCommerce.CatalogModule.Data.MySql;
 using VirtoCommerce.CatalogModule.Data.PostgreSql;
 using VirtoCommerce.CatalogModule.Data.Repositories;
@@ -51,6 +53,7 @@ using VirtoCommerce.ExportModule.Data.Services;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.ExportImport;
+using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
@@ -175,6 +178,14 @@ namespace VirtoCommerce.CatalogModule.Web
             serviceCollection.AddTransient<IndexProductChangedEventHandler>();
             serviceCollection.AddTransient<VideoOwnerChangingEventHandler>();
             serviceCollection.AddTransient<TrackSpecialChangesEventHandler>();
+
+            serviceCollection.AddTransient<AutomaticLinksJob>();
+            serviceCollection.AddBackgroundJob<UpdateAutomaticLinksJobHandler, AutomaticLinksJobPayload>();
+            serviceCollection.AddBackgroundJob<DeleteAutomaticLinksJobHandler, AutomaticLinksJobPayload>();
+            serviceCollection.AddBackgroundJob<UpdateProductsJobHandler, UpdateProductsJobPayload>();
+            // Not triggerable by name: this job writes audit-log rows, and an OperationLog whose Id matches an existing
+            // row takes ChangeLogService.SaveChangesAsync's Patch branch, so a caller-supplied payload must never reach it.
+            serviceCollection.AddBackgroundJob<LogEntityChangesJobHandler, LogEntityChangesJobPayload>(triggerable: false);
 
             serviceCollection.AddTransient<ISeoResolver, CatalogSeoResolver>();
             serviceCollection.AddTransient<ISeoResolver, BrandSeoResolver>();

--- a/src/VirtoCommerce.CatalogModule.Web/VirtoCommerce.CatalogModule.Web.csproj
+++ b/src/VirtoCommerce.CatalogModule.Web/VirtoCommerce.CatalogModule.Web.csproj
@@ -27,7 +27,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1052.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogModule.BulkActions\VirtoCommerce.CatalogModule.BulkActions.csproj" />

--- a/src/VirtoCommerce.CatalogModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogModule.Web/module.manifest
@@ -7,7 +7,6 @@
   <platformVersion>3.1052.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
-    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.BulkActionsModule" version="3.1002.0" optional="true" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Export" version="3.1002.0" optional="true" />

--- a/src/VirtoCommerce.CatalogModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogModule.Web/module.manifest
@@ -4,9 +4,10 @@
   <version>3.1040.0</version>
   <version-tag />
 
-  <platformVersion>3.1039.0</platformVersion>
+  <platformVersion>3.1052.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.BackgroundJobs" version="3.1050.0" />
     <dependency id="VirtoCommerce.BulkActionsModule" version="3.1002.0" optional="true" />
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Export" version="3.1002.0" optional="true" />

--- a/tests/VirtoCommerce.CatalogModule.Tests/BackgroundJobEnqueueTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/BackgroundJobEnqueueTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using VirtoCommerce.CatalogModule.Core.Events;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Data.Handlers;
+using VirtoCommerce.CatalogModule.Data.Jobs;
+using VirtoCommerce.CatalogModule.Data.Repositories;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Jobs;
+using Xunit;
+
+namespace VirtoCommerce.CatalogModule.Tests
+{
+    // Any other test class that enqueues through the static BackgroundJob facade must join this collection:
+    // the facade has no reset API (Initialize rejects null), so Dispose leaves a DISPOSED provider behind in
+    // the static, and a class racing this one would see ObjectDisposedException from it.
+    [Collection(nameof(BackgroundJobEnqueueTests))]
+    public class BackgroundJobEnqueueTests
+    {
+        [Fact]
+        public async Task LogChanges_ProductChanged_EnqueuesOneJobWithOneLogPerChangedEntry()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new LogChangesChangedEventHandler(Mock.Of<IChangeLogService>(), () => Mock.Of<ICatalogRepository>());
+
+            var message = new ProductChangedEvent(
+            [
+                new GenericChangedEntry<CatalogProduct>(new CatalogProduct { Id = "p1" }, new CatalogProduct { Id = "p1" }, EntryState.Modified),
+                new GenericChangedEntry<CatalogProduct>(new CatalogProduct { Id = "p2" }, new CatalogProduct { Id = "p2" }, EntryState.Added),
+            ]);
+
+            //Act
+            await handler.Handle(message);
+
+            //Assert
+            var payload = Assert.IsType<LogEntityChangesJobPayload>(capture.Payload);
+            Assert.Equal(1, capture.EnqueueCount);
+            Assert.Equal(["p1", "p2"], payload.OperationLogs.Select(x => x.ObjectId));
+        }
+
+        [Fact]
+        public async Task TrackSpecialChanges_ParentChanged_EnqueuesTheAffectedCategoryIds()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new TrackSpecialChangesEventHandler(() => Mock.Of<ICatalogRepository>(), Mock.Of<Core.Services.IItemService>());
+
+            var message = new CategoryChangedEvent(
+            [
+                new GenericChangedEntry<Category>(
+                    new Category { Id = "c1", CatalogId = "cat", ParentId = "new-parent" },
+                    new Category { Id = "c1", CatalogId = "cat", ParentId = "old-parent" },
+                    EntryState.Modified),
+            ]);
+
+            //Act
+            await handler.Handle(message);
+
+            //Assert
+            var payload = Assert.IsType<UpdateProductsJobPayload>(capture.Payload);
+            Assert.Equal(1, capture.EnqueueCount);
+            Assert.Equal(["c1"], payload.CategoryIds);
+        }
+
+        [Fact]
+        public async Task TrackSpecialChanges_NothingSpecialChanged_EnqueuesNothing()
+        {
+            //Arrange
+            using var capture = new EnqueueCapture();
+            var handler = new TrackSpecialChangesEventHandler(() => Mock.Of<ICatalogRepository>(), Mock.Of<Core.Services.IItemService>());
+
+            var category = new Category { Id = "c1", CatalogId = "cat", ParentId = "parent", IsActive = true };
+
+            //Act
+            await handler.Handle(new CategoryChangedEvent([new GenericChangedEntry<Category>(category, category, EntryState.Modified)]));
+
+            //Assert
+            Assert.Equal(0, capture.EnqueueCount);
+        }
+
+        // Captures what a handler enqueued through the static BackgroundJob facade. IBackgroundJob is registered
+        // Scoped here exactly as the engine module registers it, so this also proves the facade's per-call scope
+        // resolves it - the handlers themselves are root-resolved and must never hold it.
+        private sealed class EnqueueCapture : IDisposable
+        {
+            private readonly ServiceProvider _provider;
+
+            public EnqueueCapture()
+            {
+                Setup<LogEntityChangesJobHandler>();
+                Setup<UpdateProductsJobHandler>();
+
+                var services = new ServiceCollection();
+                services.AddScoped(_ => BackgroundJobMock.Object);
+                _provider = services.BuildServiceProvider(validateScopes: true);
+
+                BackgroundJob.Initialize(_provider);
+            }
+
+            public Mock<IBackgroundJob> BackgroundJobMock { get; } = new();
+
+            public object Payload { get; private set; }
+
+            public int EnqueueCount { get; private set; }
+
+            public void Dispose()
+            {
+                _provider.Dispose();
+            }
+
+            private void Setup<THandler>()
+                where THandler : class
+            {
+                BackgroundJobMock
+                    .Setup(x => x.Enqueue<THandler>(It.IsAny<object>(), It.IsAny<EnqueueOptions>(), It.IsAny<CancellationToken>()))
+                    .Callback<object, EnqueueOptions, CancellationToken>((payload, _, _) =>
+                    {
+                        Payload = payload;
+                        EnqueueCount++;
+                    })
+                    .ReturnsAsync("job-id");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5490
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.1041.0-pr-903-0c47.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches catalog indexing/search side effects (product resaves, change logs) and breaks legacy Hangfire job dispatch; upgrade requires platform 3.1052 and coordinated deployment so in-flight Hangfire jobs are not relied on.
> 
> **Overview**
> Moves catalog deferred work onto **VirtoCommerce Platform 3.1052** background jobs by dropping **Hangfire** (`VirtoCommerce.Platform.Hangfire` and direct `Hangfire` usage) and bumping platform package/manifest versions accordingly.
> 
> **Enqueue paths** now use the static `BackgroundJob.Enqueue<THandler>(payload)` facade with typed **handlers and payloads**: change-log persistence (`LogEntityChangesJobHandler`), product resave after category hierarchy/visibility changes (`UpdateProductsJobHandler`), and category automatic-link rebuild/delete (`UpdateAutomaticLinksJobHandler` / `DeleteAutomaticLinksJobHandler`). Event handlers and the categories API were updated to build payloads and await enqueue; `LogChangesChangedEventHandler.InnerHandle` is now **`Task`-returning** (breaking for compiled overrides). `LogEntityChangesJobHandler` is registered **`triggerable: false`** so arbitrary payloads cannot hit audit-log patch behavior.
> 
> **Compatibility notes:** obsolete `AutomaticLinksJob` **`IJobCancellationToken`** overloads are removed, so legacy Hangfire queue items targeting those methods will not run; new work goes through the new handlers. `BackgroundJobEnqueueTests` asserts enqueue behavior for the main event handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c4796692b691170c7de4366c95def6ab07566fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->