### PR TITLE
VCST-5849: Exclude variations loading from create links

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
@@ -124,7 +124,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
             }
 
             var searchResult = await SearchAllAuthorizedListEntriesAsync(authorizedCriteria, cancellationToken);
-            var hasLinkEntries = await LoadCatalogEntriesAsync<IHasLinks>(searchResult.Select(x => x.Id).ToArray());
+            var hasLinkEntries = await LoadCatalogEntriesAsync<IHasLinks>(searchResult.Select(x => x.Id).ToArray(), excludeVariations: true);
 
             if (hasLinkEntries.Count == 0)
             {
@@ -195,7 +195,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
         public async Task<ActionResult> DeleteLinks([FromBody] CategoryLink[] links)
         {
             var entryIds = links.Select(x => x.EntryId).ToArray();
-            var hasLinkEntries = await LoadCatalogEntriesAsync<IHasLinks>(entryIds);
+            var hasLinkEntries = await LoadCatalogEntriesAsync<IHasLinks>(entryIds, excludeVariations: true);
 
             if (!await authorizationService.AuthorizeEntitiesAsync(
                     User,

--- a/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
+++ b/src/VirtoCommerce.CatalogModule.Web/Controllers/Api/CatalogModuleListEntryController.cs
@@ -67,7 +67,7 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
         public async Task<ActionResult> CreateLinks([FromBody] CategoryLink[] links)
         {
             var entryIds = links.Select(x => x.EntryId).ToArray();
-            var hasLinkEntries = await LoadCatalogEntriesAsync<IHasLinks>(entryIds);
+            var hasLinkEntries = await LoadCatalogEntriesAsync<IHasLinks>(entryIds, excludeVariations: true);
 
             if (!await authorizationService.AuthorizeEntitiesAsync(
                     User,
@@ -387,12 +387,18 @@ namespace VirtoCommerce.CatalogModule.Web.Controllers.Api
             }
         }
 
-        private async Task<IList<T>> LoadCatalogEntriesAsync<T>(string[] ids)
+        private async Task<IList<T>> LoadCatalogEntriesAsync<T>(string[] ids, bool excludeVariations = false)
         {
+            var responseGroup = ItemResponseGroup.Links | ItemResponseGroup.ItemProperties;
 #pragma warning disable CS0618 // Variations can be used here
-            var products = await itemService.GetAsync(ids, (ItemResponseGroup.Links | ItemResponseGroup.ItemProperties | ItemResponseGroup.Variations).ToString());
+            if (!excludeVariations)
+            {
+                responseGroup |= ItemResponseGroup.Variations;
+            }
 #pragma warning restore CS0618
-            var categories = await categoryService.GetAsync(ids.Except(products.Select(x => x.Id)).ToList(), (CategoryResponseGroup.WithLinks).ToString());
+
+            var products = await itemService.GetAsync(ids, responseGroup.ToString());
+            var categories = await categoryService.GetAsync(ids.Except(products.Select(x => x.Id)).ToList(), CategoryResponseGroup.WithLinks.ToString());
             return products.OfType<T>().Concat(categories.OfType<T>()).ToList();
         }
     }


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5849
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.1043.0-pr-905-ffa6.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to link CRUD loading paths; default behavior is unchanged for search and move operations.
> 
> **Overview**
> Link create, bulk create, and delete endpoints no longer load product **variations** when fetching catalog entries for authorization and link updates.
> 
> `LoadCatalogEntriesAsync` gains an optional `excludeVariations` flag that omits `ItemResponseGroup.Variations` from the item service response group while still loading links and item properties. **SearchLinks** and other callers keep the previous behavior (variations still loaded by default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa68caa1e49cc4d730d4374ff088fa7c7de1ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->