### PR TITLE
VCST-5851: Sort facet values by dictionary priority in an explicit direction

### DIFF
--- a/src/VirtoCommerce.CatalogModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CatalogModule.Core/ModuleConstants.cs
@@ -19,7 +19,15 @@ namespace VirtoCommerce.CatalogModule.Core
         public const string ConfigurationSectionFilesScope = "product-configuration";
 
         public const string TermValuesSortingTypeScore = "Score";
+
+        /// <summary>
+        /// Kept for stores configured before priority sorting was split into an explicit direction.
+        /// Behaves as <see cref="TermValuesSortingTypePriorityAscending"/>.
+        /// </summary>
         public const string TermValuesSortingTypePriority = "Priority";
+
+        public const string TermValuesSortingTypePriorityAscending = "PriorityAscending";
+        public const string TermValuesSortingTypePriorityDescending = "PriorityDescending";
         public const string TermValuesSortingTypeNameAscending = "NameAscending";
         public const string TermValuesSortingTypeNameDescending = "NameDescending";
         public const string TermValuesSortingTypeNumericAscending = "NumericAscending";

--- a/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/AggregationConverter.cs
+++ b/src/VirtoCommerce.CatalogModule.Data/Search/Indexing/AggregationConverter.cs
@@ -40,6 +40,8 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
         private readonly IStoreService _storeService;
         private readonly ICatalogService _catalogService;
 
+        private sealed record PrioritySortingRequest(Aggregation Aggregation, string PropertyName, bool Descending);
+
         public AggregationConverter(
             IBrowseFilterService browseFilterService,
             IPropertyService propertyService,
@@ -543,7 +545,7 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
             }
 
             var attributeFilters = browseFilters.OfType<AttributeFilter>().ToList();
-            var prioritySortingMap = new List<Tuple<Aggregation, string>>();
+            var prioritySortingRequests = new List<PrioritySortingRequest>();
 
             foreach (var aggregation in result.Where(x => x.AggregationType == "attr" && !x.Items.IsNullOrEmpty()))
             {
@@ -555,14 +557,19 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
 
                 if (!TryApplySimpleSorting(aggregation, attributeFilter.TermValuesSortingType))
                 {
-                    // special case: defer priority sorting until dictionary items are loaded
-                    prioritySortingMap.Add(new Tuple<Aggregation, string>(aggregation, attributeFilter.Key ?? aggregation.Field));
+                    // special case: defer priority sorting until dictionary items are loaded.
+                    // The switch above matched one of the priority constants exactly, so a plain
+                    // comparison is enough here and stays consistent with its ordinal matching.
+                    prioritySortingRequests.Add(new PrioritySortingRequest(
+                        aggregation,
+                        attributeFilter.Key ?? aggregation.Field,
+                        attributeFilter.TermValuesSortingType == ModuleConstants.TermValuesSortingTypePriorityDescending));
                 }
             }
 
-            if (prioritySortingMap.Count > 0)
+            if (prioritySortingRequests.Count > 0)
             {
-                await SortByPriorityAsync(prioritySortingMap, catalogId);
+                await SortByPriorityAsync(prioritySortingRequests, catalogId);
             }
         }
 
@@ -571,6 +578,8 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
             switch (sortingType)
             {
                 case ModuleConstants.TermValuesSortingTypePriority:
+                case ModuleConstants.TermValuesSortingTypePriorityAscending:
+                case ModuleConstants.TermValuesSortingTypePriorityDescending:
                     return false;
                 case ModuleConstants.TermValuesSortingTypeNameAscending:
                     aggregation.Items = [.. aggregation.Items.OrderBy(x => x.Value)];
@@ -606,23 +615,25 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
                 : null;
         }
 
-        private async Task SortByPriorityAsync(List<Tuple<Aggregation, string>> prioritySortingMap, string catalogId)
+        private async Task SortByPriorityAsync(List<PrioritySortingRequest> prioritySortingRequests, string catalogId)
         {
             var allCatalogProperties = await _propertyService.GetAllCatalogPropertiesAsync(catalogId);
-            var propertyNames = prioritySortingMap.Select(x => x.Item2).ToList();
-            var propertiesMap = allCatalogProperties
+            var propertyNames = prioritySortingRequests.Select(x => x.PropertyName).ToList();
+
+            // There can be many properties with the same name. A virtual catalog reports one per linked
+            // catalog, and only some of them carry the dictionary items, so all of them have to be collected.
+            var properties = allCatalogProperties
                 .Where(p => propertyNames.ContainsIgnoreCase(p.Name))
-                .Select(x => new KeyValue { Key = x.Id, Value = x.Name })
                 .ToArray();
 
-            if (propertiesMap.Length == 0)
+            if (properties.Length == 0)
             {
                 return;
             }
 
             var dictionaryItems = await _propDictItemsSearchService.SearchAllNoCloneAsync(new PropertyDictionaryItemSearchCriteria
             {
-                PropertyIds = [.. propertiesMap.Select(x => x.Key)],
+                PropertyIds = [.. properties.Select(x => x.Id)],
             });
 
             if (dictionaryItems.Count == 0)
@@ -630,26 +641,56 @@ namespace VirtoCommerce.CatalogModule.Data.Search.Indexing
                 return;
             }
 
-            var dictionaryItemsMap = dictionaryItems
-                .GroupBy(x => x.PropertyId)
-                .ToDictionary(x => x.Key, x => x.ToList());
+            var sortOrdersByPropertyName = properties
+                .GroupBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    g => g.Key,
+                    g => GetSortOrdersByAlias(g.Select(p => p.Id).ToHashSet(StringComparer.OrdinalIgnoreCase), dictionaryItems),
+                    StringComparer.OrdinalIgnoreCase);
 
-            foreach (var (aggregation, propertyName) in prioritySortingMap.Select(t => (t.Item1, t.Item2)))
+            foreach (var request in prioritySortingRequests)
             {
-                var propertyMap = propertiesMap.FirstOrDefault(x => x.Value.EqualsIgnoreCase(propertyName));
-                if (propertyMap == null || !dictionaryItemsMap.TryGetValue(propertyMap.Key, out var items))
+                if (!sortOrdersByPropertyName.TryGetValue(request.PropertyName, out var sortOrders) || sortOrders.Count == 0)
                 {
                     continue;
                 }
 
-                // alias is value
-                aggregation.Items = [.. aggregation.Items.OrderByDescending(x =>
-                {
-                    var item = items.FirstOrDefault(i => i.Alias.EqualsIgnoreCase(x.Value?.ToString()));
-                    return item?.SortOrder ?? 0;
-                })];
+                // alias is value; values with no dictionary item have no priority and always go last
+                var keyed = request.Aggregation.Items.Select(x => (Item: x, SortOrder: GetSortOrder(sortOrders, x.Value)));
+                var ordered = keyed.OrderBy(t => t.SortOrder.HasValue ? 0 : 1);
+                ordered = request.Descending
+                    ? ordered.ThenByDescending(t => t.SortOrder)
+                    : ordered.ThenBy(t => t.SortOrder);
+
+                request.Aggregation.Items =
+                    [.. ordered.ThenBy(t => t.Item.Value?.ToString(), StringComparer.OrdinalIgnoreCase).Select(t => t.Item)];
             }
         }
+
+        private static Dictionary<string, int> GetSortOrdersByAlias(HashSet<string> propertyIds, IList<PropertyDictionaryItem> dictionaryItems)
+        {
+            // The same alias can arrive from several same-named properties, and often only one of the
+            // copies has priorities filled in. Prefer the strongest priority that was actually set,
+            // treating the default 0 as "not set" while any duplicate carries an explicit value.
+            return dictionaryItems
+                .Where(x => propertyIds.Contains(x.PropertyId) && !string.IsNullOrEmpty(x.Alias))
+                .GroupBy(x => x.Alias, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.Select(x => x.SortOrder).Where(x => x != 0).DefaultIfEmpty(0).Min(),
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static int? GetSortOrder(Dictionary<string, int> sortOrders, object value)
+        {
+            var alias = value?.ToString();
+
+            return !string.IsNullOrEmpty(alias) && sortOrders.TryGetValue(alias, out var sortOrder)
+                ? sortOrder
+                : null;
+        }
+
+
 
         protected virtual async Task AddLabelsAsync(IList<Aggregation> aggregations, string catalogId, IList<IBrowseFilter> browseFilters)
         {

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/de.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/de.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "Punktzahl",
           "priority": "Priorität",
+          "priorityAscending": "Priorität aufsteigend",
+          "priorityDescending": "Priorität absteigend",
           "nameAscending": "Name aufsteigend",
           "nameDescending": "Name absteigend",
           "numericAscending": "Numerisch aufsteigend",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/en.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/en.VirtoCommerce.Catalog.json
@@ -732,6 +732,8 @@
         "sorting-type-labels": {
           "score": "Score",
           "priority": "Priority",
+          "priorityAscending": "Priority ascending",
+          "priorityDescending": "Priority descending",
           "nameAscending": "Name ascending",
           "nameDescending": "Name descending",
           "numericAscending": "Numeric ascending",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/es.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/es.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "Puntuación",
           "priority": "Prioridad",
+          "priorityAscending": "Prioridad ascendente",
+          "priorityDescending": "Prioridad descendente",
           "nameAscending": "Nombre ascendente",
           "nameDescending": "Nombre descendente",
           "numericAscending": "Numérico ascendente",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/fi.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/fi.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "Pisteet",
           "priority": "Prioriteetti",
+          "priorityAscending": "Prioriteetti nouseva",
+          "priorityDescending": "Prioriteetti laskeva",
           "nameAscending": "Nimi nouseva",
           "nameDescending": "Nimi laskeva",
           "numericAscending": "Numeerinen nouseva",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/fr.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/fr.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "Score",
           "priority": "Priorité",
+          "priorityAscending": "Priorité croissante",
+          "priorityDescending": "Priorité décroissante",
           "nameAscending": "Nom croissant",
           "nameDescending": "Nom décroissant",
           "numericAscending": "Numérique croissant",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/it.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/it.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "Punteggio",
           "priority": "Priorità",
+          "priorityAscending": "Priorità crescente",
+          "priorityDescending": "Priorità decrescente",
           "nameAscending": "Nome crescente",
           "nameDescending": "Nome decrescente",
           "numericAscending": "Numerico crescente",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/ja.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/ja.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "スコア",
           "priority": "優先度",
+          "priorityAscending": "優先度（昇順）",
+          "priorityDescending": "優先度（降順）",
           "nameAscending": "名前（昇順）",
           "nameDescending": "名前（降順）",
           "numericAscending": "数値（昇順）",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/no.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/no.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "Poeng",
           "priority": "Prioritet",
+          "priorityAscending": "Prioritet stigende",
+          "priorityDescending": "Prioritet synkende",
           "nameAscending": "Navn stigende",
           "nameDescending": "Navn synkende",
           "numericAscending": "Numerisk stigende",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/pl.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/pl.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "Wynik",
           "priority": "Priorytet",
+          "priorityAscending": "Priorytet rosnąco",
+          "priorityDescending": "Priorytet malejąco",
           "nameAscending": "Nazwa rosnąco",
           "nameDescending": "Nazwa malejąco",
           "numericAscending": "Numerycznie rosnąco",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/pt.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/pt.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "Pontuação",
           "priority": "Prioridade",
+          "priorityAscending": "Prioridade ascendente",
+          "priorityDescending": "Prioridade descendente",
           "nameAscending": "Nome ascendente",
           "nameDescending": "Nome descendente",
           "numericAscending": "Numérico ascendente",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/ru.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/ru.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "Оценка",
           "priority": "Приоритет",
+          "priorityAscending": "Приоритет по возрастанию",
+          "priorityDescending": "Приоритет по убыванию",
           "nameAscending": "Имя по возрастанию",
           "nameDescending": "Имя по убыванию",
           "numericAscending": "Числовое по возрастанию",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/sv.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/sv.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "Poäng",
           "priority": "Prioritet",
+          "priorityAscending": "Prioritet stigande",
+          "priorityDescending": "Prioritet fallande",
           "nameAscending": "Namn stigande",
           "nameDescending": "Namn fallande",
           "numericAscending": "Numerisk stigande",

--- a/src/VirtoCommerce.CatalogModule.Web/Localizations/zh.VirtoCommerce.Catalog.json
+++ b/src/VirtoCommerce.CatalogModule.Web/Localizations/zh.VirtoCommerce.Catalog.json
@@ -689,6 +689,8 @@
         "sorting-type-labels": {
           "score": "评分",
           "priority": "优先级",
+          "priorityAscending": "优先级升序",
+          "priorityDescending": "优先级降序",
           "nameAscending": "名称升序",
           "nameDescending": "名称降序",
           "numericAscending": "数值升序",

--- a/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/aggregation-properties-details.js
+++ b/src/VirtoCommerce.CatalogModule.Web/Scripts/blades/aggregation-properties-details.js
@@ -17,8 +17,12 @@ angular.module('virtoCommerce.catalogModule')
                     nameKey: "catalog.blades.aggregation-properties-details.sorting-type-labels.score",
                 },
                 {
-                    id: "Priority",
-                    nameKey: "catalog.blades.aggregation-properties-details.sorting-type-labels.priority",
+                    id: "PriorityAscending",
+                    nameKey: "catalog.blades.aggregation-properties-details.sorting-type-labels.priorityAscending",
+                },
+                {
+                    id: "PriorityDescending",
+                    nameKey: "catalog.blades.aggregation-properties-details.sorting-type-labels.priorityDescending",
                 },
                 {
                     id: "NameAscending",
@@ -39,6 +43,13 @@ angular.module('virtoCommerce.catalogModule')
 
             function initializeBlade() {
                 $scope.isValid = true;
+
+                // Stores configured before priority sorting was split into an explicit direction hold a
+                // bare "Priority", which now means ascending. Show it as such instead of a blank dropdown.
+                if (blade.property.termValuesSortingType === 'Priority') {
+                    blade.property.termValuesSortingType = 'PriorityAscending';
+                }
+
                 blade.originalProperty = blade.property;
                 blade.property = angular.copy(blade.property);
 

--- a/src/VirtoCommerce.CatalogModule.Web/package-lock.json
+++ b/src/VirtoCommerce.CatalogModule.Web/package-lock.json
@@ -453,13 +453,16 @@
       "dev": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/big.js": {
@@ -473,9 +476,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -484,9 +487,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -504,11 +507,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -542,9 +545,9 @@
       "license": "0BSD"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -724,9 +727,9 @@
       "license": "0BSD"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.425",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.425.tgz",
+      "integrity": "sha512-QvPtl41EUOnuT1HBvMKgxXRIaHNcagBPs50u7VULzhZXaGfqTbZyE16LQsctZ/RQHlGu+FOWeDTR4mY6YbeF1g==",
       "dev": true,
       "license": "ISC"
     },
@@ -855,9 +858,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -1354,9 +1357,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1407,11 +1410,14 @@
       "license": "0BSD"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+      "integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -1627,9 +1633,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -1647,7 +1653,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2010,9 +2016,9 @@
       "dev": true
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/tests/VirtoCommerce.CatalogModule.Tests/AggregationConverterSortingTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/AggregationConverterSortingTests.cs
@@ -9,7 +9,10 @@ using VirtoCommerce.CatalogModule.Core.Search;
 using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.CatalogModule.Data.Search.BrowseFilters;
 using VirtoCommerce.CatalogModule.Data.Search.Indexing;
+using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.SearchModule.Core.Model;
+using VirtoCommerce.StoreModule.Core.Model;
+using VirtoCommerce.StoreModule.Core.Services;
 using Xunit;
 
 namespace VirtoCommerce.CatalogModule.Tests
@@ -17,7 +20,9 @@ namespace VirtoCommerce.CatalogModule.Tests
     public class AggregationConverterSortingTests
     {
         private const string PropertyId = "color-property-id";
+        private const string LinkedPropertyId = "linked-color-property-id";
         private const string PropertyFieldName = "Color";
+        private const string StoreId = "Store-Test";
 
         private static readonly IList<AggregationResponseValue> _termResponseValues =
         [
@@ -27,6 +32,11 @@ namespace VirtoCommerce.CatalogModule.Tests
         ];
 
         private static readonly Property ColorProperty = new() { Id = PropertyId, Name = PropertyFieldName, DisplayNames = [] };
+
+        /// <summary>
+        /// A second property with the same name, as a virtual catalog reports for every linked catalog.
+        /// </summary>
+        private static readonly Property LinkedColorProperty = new() { Id = LinkedPropertyId, Name = PropertyFieldName, DisplayNames = [] };
 
         private static readonly List<PropertyDictionaryItem> DictinaryItems =
         [
@@ -109,10 +119,30 @@ namespace VirtoCommerce.CatalogModule.Tests
         }
 
         [Fact]
-        public async Task SortAggregationItems_Priority_ItemsSortedBySortOrderDescending()
+        public async Task SortAggregationItems_PriorityAscending_ItemsSortedBySortOrderAscending()
+        {
+            // Arrange: "The lowest value will be used first" — Crimson=10, Black=50, Azure=100
+            var converter = GetAggregationConverter(ModuleConstants.TermValuesSortingTypePriorityAscending);
+            var criteria = new ProductIndexedSearchCriteria();
+            var responses = BuildAggregationResponses();
+
+            // Act
+            var aggregations = await converter.ConvertAggregationsAsync(responses, criteria);
+
+            // Assert
+            Assert.Single(aggregations);
+            var items = aggregations[0].Items;
+            Assert.Equal(3, items.Length);
+            Assert.Equal("Crimson", items[0].Value);
+            Assert.Equal("Black", items[1].Value);
+            Assert.Equal("Azure", items[2].Value);
+        }
+
+        [Fact]
+        public async Task SortAggregationItems_PriorityDescending_ItemsSortedBySortOrderDescending()
         {
             // Arrange
-            var converter = GetAggregationConverter(ModuleConstants.TermValuesSortingTypePriority);
+            var converter = GetAggregationConverter(ModuleConstants.TermValuesSortingTypePriorityDescending);
             var criteria = new ProductIndexedSearchCriteria();
             var responses = BuildAggregationResponses();
 
@@ -126,6 +156,162 @@ namespace VirtoCommerce.CatalogModule.Tests
             Assert.Equal("Azure", items[0].Value);
             Assert.Equal("Black", items[1].Value);
             Assert.Equal("Crimson", items[2].Value);
+        }
+
+        [Fact]
+        public async Task SortAggregationItems_LegacyPriority_ItemsSortedBySortOrderAscending()
+        {
+            // Arrange: stores configured before the ascending/descending split persisted a bare "Priority".
+            // It has to follow the documented contract, which is the lowest value first.
+            var converter = GetAggregationConverter(ModuleConstants.TermValuesSortingTypePriority);
+            var criteria = new ProductIndexedSearchCriteria();
+            var responses = BuildAggregationResponses();
+
+            // Act
+            var aggregations = await converter.ConvertAggregationsAsync(responses, criteria);
+
+            // Assert
+            Assert.Single(aggregations);
+            var items = aggregations[0].Items;
+            Assert.Equal(3, items.Length);
+            Assert.Equal("Crimson", items[0].Value);
+            Assert.Equal("Black", items[1].Value);
+            Assert.Equal("Azure", items[2].Value);
+        }
+
+        [Fact]
+        public async Task SortAggregationItems_PriorityAscending_ValuesWithoutDictionaryItemGoLast()
+        {
+            // Arrange: Crimson has no dictionary item, so it has no priority at all
+            var converter = GetAggregationConverter(
+                ModuleConstants.TermValuesSortingTypePriorityAscending,
+                dictionaryItems:
+                [
+                    new PropertyDictionaryItem { PropertyId = PropertyId, Alias = "Azure", SortOrder = 100, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = PropertyId, Alias = "Black", SortOrder = 50, LocalizedValues = [] },
+                ]);
+            var criteria = new ProductIndexedSearchCriteria();
+            var responses = BuildAggregationResponses();
+
+            // Act
+            var aggregations = await converter.ConvertAggregationsAsync(responses, criteria);
+
+            // Assert
+            var items = aggregations[0].Items;
+            Assert.Equal(3, items.Length);
+            Assert.Equal("Black", items[0].Value);
+            Assert.Equal("Azure", items[1].Value);
+            Assert.Equal("Crimson", items[2].Value);
+        }
+
+        [Fact]
+        public async Task SortAggregationItems_PriorityDescending_ValuesWithoutDictionaryItemGoLast()
+        {
+            // Arrange: values without a priority must go last in this direction too, never first
+            var converter = GetAggregationConverter(
+                ModuleConstants.TermValuesSortingTypePriorityDescending,
+                dictionaryItems:
+                [
+                    new PropertyDictionaryItem { PropertyId = PropertyId, Alias = "Azure", SortOrder = 100, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = PropertyId, Alias = "Black", SortOrder = 50, LocalizedValues = [] },
+                ]);
+            var criteria = new ProductIndexedSearchCriteria();
+            var responses = BuildAggregationResponses();
+
+            // Act
+            var aggregations = await converter.ConvertAggregationsAsync(responses, criteria);
+
+            // Assert
+            var items = aggregations[0].Items;
+            Assert.Equal(3, items.Length);
+            Assert.Equal("Azure", items[0].Value);
+            Assert.Equal("Black", items[1].Value);
+            Assert.Equal("Crimson", items[2].Value);
+        }
+
+        [Fact]
+        public async Task SortAggregationItems_PriorityAscending_EqualSortOrdersFallBackToValue()
+        {
+            // Arrange
+            var converter = GetAggregationConverter(
+                ModuleConstants.TermValuesSortingTypePriorityAscending,
+                dictionaryItems:
+                [
+                    new PropertyDictionaryItem { PropertyId = PropertyId, Alias = "Azure", SortOrder = 10, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = PropertyId, Alias = "Black", SortOrder = 10, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = PropertyId, Alias = "Crimson", SortOrder = 5, LocalizedValues = [] },
+                ]);
+            var criteria = new ProductIndexedSearchCriteria();
+            var responses = BuildAggregationResponses();
+
+            // Act
+            var aggregations = await converter.ConvertAggregationsAsync(responses, criteria);
+
+            // Assert
+            var items = aggregations[0].Items;
+            Assert.Equal(3, items.Length);
+            Assert.Equal("Crimson", items[0].Value);
+            Assert.Equal("Azure", items[1].Value);
+            Assert.Equal("Black", items[2].Value);
+        }
+
+        [Fact]
+        public async Task SortAggregationItems_PriorityAscending_SameNamedPropertiesWithUnsetPriorities()
+        {
+            // Arrange: both same-named properties define the same aliases, but only the linked one
+            // has priorities filled in. The unset zeros must not swamp the priorities that were set.
+            var converter = GetAggregationConverter(
+                ModuleConstants.TermValuesSortingTypePriorityAscending,
+                properties: [ColorProperty, LinkedColorProperty],
+                dictionaryItems:
+                [
+                    new PropertyDictionaryItem { PropertyId = PropertyId, Alias = "Azure", SortOrder = 0, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = PropertyId, Alias = "Black", SortOrder = 0, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = PropertyId, Alias = "Crimson", SortOrder = 0, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = LinkedPropertyId, Alias = "Azure", SortOrder = 100, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = LinkedPropertyId, Alias = "Black", SortOrder = 50, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = LinkedPropertyId, Alias = "Crimson", SortOrder = 10, LocalizedValues = [] },
+                ]);
+            var criteria = new ProductIndexedSearchCriteria();
+            var responses = BuildAggregationResponses();
+
+            // Act
+            var aggregations = await converter.ConvertAggregationsAsync(responses, criteria);
+
+            // Assert
+            var items = aggregations[0].Items;
+            Assert.Equal(3, items.Length);
+            Assert.Equal("Crimson", items[0].Value);
+            Assert.Equal("Black", items[1].Value);
+            Assert.Equal("Azure", items[2].Value);
+        }
+
+        [Fact]
+        public async Task SortAggregationItems_PriorityAscending_SameNamedPropertiesFromLinkedCatalogs()
+        {
+            // Arrange: a virtual catalog reports several properties named "Color", one per linked catalog.
+            // The dictionary items live on the linked property, not on the first one that matches the name.
+            var converter = GetAggregationConverter(
+                ModuleConstants.TermValuesSortingTypePriorityAscending,
+                properties: [ColorProperty, LinkedColorProperty],
+                dictionaryItems:
+                [
+                    new PropertyDictionaryItem { PropertyId = LinkedPropertyId, Alias = "Azure", SortOrder = 100, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = LinkedPropertyId, Alias = "Black", SortOrder = 50, LocalizedValues = [] },
+                    new PropertyDictionaryItem { PropertyId = LinkedPropertyId, Alias = "Crimson", SortOrder = 10, LocalizedValues = [] },
+                ]);
+            var criteria = new ProductIndexedSearchCriteria();
+            var responses = BuildAggregationResponses();
+
+            // Act
+            var aggregations = await converter.ConvertAggregationsAsync(responses, criteria);
+
+            // Assert
+            var items = aggregations[0].Items;
+            Assert.Equal(3, items.Length);
+            Assert.Equal("Crimson", items[0].Value);
+            Assert.Equal("Black", items[1].Value);
+            Assert.Equal("Azure", items[2].Value);
         }
 
         [Fact]
@@ -241,6 +427,82 @@ namespace VirtoCommerce.CatalogModule.Tests
             Assert.Equal("xyz", items[3].Value);
         }
 
+        [Theory]
+        [InlineData(ModuleConstants.TermValuesSortingTypePriority, "Crimson", "Black", "Azure")]
+        [InlineData(ModuleConstants.TermValuesSortingTypePriorityAscending, "Crimson", "Black", "Azure")]
+        [InlineData(ModuleConstants.TermValuesSortingTypePriorityDescending, "Azure", "Black", "Crimson")]
+        public async Task SortAggregationItems_SortingTypeReadFromPersistedStoreConfig(
+            string persistedSortingType, string first, string second, string third)
+        {
+            // Arrange: take the sorting type through the real persistence path instead of a hand-built
+            // filter, so the whole backend mapping is covered - store setting, deserialization, converter.
+            var converter = GetAggregationConverterWithPersistedConfig(persistedSortingType);
+            var criteria = new ProductIndexedSearchCriteria { StoreId = StoreId };
+            var responses = BuildAggregationResponses();
+
+            // Act
+            var aggregations = await converter.ConvertAggregationsAsync(responses, criteria);
+
+            // Assert
+            Assert.Single(aggregations);
+            var items = aggregations[0].Items;
+            Assert.Equal(3, items.Length);
+            Assert.Equal(first, items[0].Value);
+            Assert.Equal(second, items[1].Value);
+            Assert.Equal(third, items[2].Value);
+        }
+
+        private static AggregationConverter GetAggregationConverterWithPersistedConfig(string persistedSortingType)
+        {
+            // The legacy XML format, which is what a store configured before the split still holds.
+            var store = new Store
+            {
+                Id = StoreId,
+                Settings =
+                [
+                    new ObjectSettingEntry(ModuleConstants.Settings.Search.FilteredBrowsing)
+                    {
+                        Value = $"""
+                                 <browsing>
+                                   <attribute key="{PropertyFieldName}">
+                                     <termValuesSortingType>{persistedSortingType}</termValuesSortingType>
+                                   </attribute>
+                                 </browsing>
+                                 """,
+                    },
+                ],
+                DynamicProperties = [],
+            };
+
+            var storeServiceMock = new Mock<IStoreService>();
+            storeServiceMock
+                .Setup(x => x.GetAsync(It.IsAny<IList<string>>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync([store]);
+
+            var propertyServiceMock = new Mock<IPropertyService>();
+            propertyServiceMock
+                .Setup(x => x.GetAllCatalogPropertiesAsync(It.IsAny<string>()))
+                .ReturnsAsync(new List<Property> { ColorProperty });
+
+            var propDictSearchServiceMock = new Mock<IPropertyDictionaryItemSearchService>();
+            propDictSearchServiceMock
+                .Setup(x => x.SearchAsync(It.IsAny<PropertyDictionaryItemSearchCriteria>(), It.IsAny<bool>()))
+                .ReturnsAsync(new PropertyDictionaryItemSearchResult { Results = DictinaryItems, TotalCount = DictinaryItems.Count });
+
+            var categoryServiceMock = new Mock<ICategoryService>();
+            categoryServiceMock
+                .Setup(x => x.GetAsync(It.IsAny<IList<string>>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ReturnsAsync(new List<Category>());
+
+            return new AggregationConverter(
+                new BrowseFilterService(storeServiceMock.Object),
+                propertyServiceMock.Object,
+                propDictSearchServiceMock.Object,
+                categoryServiceMock.Object,
+                storeServiceMock.Object,
+                null);
+        }
+
         private static IList<AggregationResponse> BuildAggregationResponsesFromIds(IList<string> ids)
         {
             return
@@ -299,8 +561,14 @@ namespace VirtoCommerce.CatalogModule.Tests
             ];
         }
 
-        private static AggregationConverter GetAggregationConverter(string termValuesSortingType)
+        private static AggregationConverter GetAggregationConverter(
+            string termValuesSortingType,
+            IList<Property> properties = null,
+            IList<PropertyDictionaryItem> dictionaryItems = null)
         {
+            properties ??= [ColorProperty];
+            dictionaryItems ??= DictinaryItems;
+
             var browseFilters = new List<IBrowseFilter>
             {
                 new AttributeFilter
@@ -318,12 +586,12 @@ namespace VirtoCommerce.CatalogModule.Tests
             var propertyServiceMock = new Mock<IPropertyService>();
             propertyServiceMock
                 .Setup(x => x.GetAllCatalogPropertiesAsync(It.IsAny<string>()))
-                .ReturnsAsync(new List<Property> { ColorProperty });
+                .ReturnsAsync(properties);
 
             var propDictSearchServiceMock = new Mock<IPropertyDictionaryItemSearchService>();
             propDictSearchServiceMock
                 .Setup(x => x.SearchAsync(It.IsAny<PropertyDictionaryItemSearchCriteria>(), It.IsAny<bool>()))
-                .ReturnsAsync(new PropertyDictionaryItemSearchResult { Results = DictinaryItems, TotalCount = DictinaryItems.Count });
+                .ReturnsAsync(new PropertyDictionaryItemSearchResult { Results = dictionaryItems, TotalCount = dictionaryItems.Count });
 
             var categoryServiceMock = new Mock<ICategoryService>();
             categoryServiceMock

--- a/tests/VirtoCommerce.CatalogModule.Tests/BrowseFilterServiceStorageTests.cs
+++ b/tests/VirtoCommerce.CatalogModule.Tests/BrowseFilterServiceStorageTests.cs
@@ -37,6 +37,60 @@ namespace VirtoCommerce.CatalogModule.Tests
             Assert.Equal("Brand", attribute.Key);
         }
 
+        [Theory]
+        [InlineData(ModuleConstants.TermValuesSortingTypeScore)]
+        [InlineData(ModuleConstants.TermValuesSortingTypePriority)]
+        [InlineData(ModuleConstants.TermValuesSortingTypePriorityAscending)]
+        [InlineData(ModuleConstants.TermValuesSortingTypePriorityDescending)]
+        [InlineData(ModuleConstants.TermValuesSortingTypeNameAscending)]
+        [InlineData(ModuleConstants.TermValuesSortingTypeNameDescending)]
+        [InlineData(ModuleConstants.TermValuesSortingTypeNumericAscending)]
+        [InlineData(ModuleConstants.TermValuesSortingTypeNumericDescending)]
+        public async Task GetStoreAggregations_RoundTripsTermValuesSortingTypeVerbatim(string sortingType)
+        {
+            // The sorting type is persisted as a free-form string, so every value has to survive
+            // the save/load cycle byte for byte, including the legacy bare "Priority".
+            var store = CreateStoreWithSetting();
+            var storeService = CreateStoreServiceMock(store);
+
+            var service = new BrowseFilterService(storeService.Object);
+
+            var filters = new List<IBrowseFilter>
+            {
+                new AttributeFilter { Key = "Color", TermValuesSortingType = sortingType },
+            };
+
+            await service.SaveStoreAggregationsAsync(StoreId, filters);
+            var result = await service.GetStoreAggregationsAsync(StoreId);
+
+            var attribute = Assert.Single(result.OfType<AttributeFilter>());
+            Assert.Equal(sortingType, attribute.TermValuesSortingType);
+        }
+
+        [Fact]
+        public async Task GetStoreAggregations_LegacyXmlPriority_DeserializesVerbatim()
+        {
+            // Stores configured before the ascending/descending split can still hold the XML format
+            // with a bare "Priority". It has to reach the aggregation converter unchanged.
+            var store = CreateStoreWithSetting(
+                """
+                <browsing>
+                  <attribute key="Color">
+                    <termValuesSortingType>Priority</termValuesSortingType>
+                  </attribute>
+                </browsing>
+                """);
+            var storeService = CreateStoreServiceMock(store);
+
+            var service = new BrowseFilterService(storeService.Object);
+
+            var result = await service.GetStoreAggregationsAsync(StoreId);
+
+            var attribute = Assert.Single(result.OfType<AttributeFilter>());
+            Assert.Equal("Color", attribute.Key);
+            Assert.Equal(ModuleConstants.TermValuesSortingTypePriority, attribute.TermValuesSortingType);
+        }
+
         [Fact]
         public async Task GetStoreAggregations_WhenStoreMissing_ReturnsNull()
         {


### PR DESCRIPTION
## Description

## Description

Dictionary facet values on a storefront now sort by priority in the direction the store asks for.

- A store facet configured to sort by priority rendered its values in reverse: the value with the
  lowest priority came last. The admin UI documents the field as "The lowest value will be used
  first", so the order was the opposite of the configured contract.
- The store facet **Sorting** dropdown now offers **Priority ascending** and **Priority descending**
  in place of a single ambiguous **Priority**. Existing stores keep working and follow the documented
  meaning — lowest value first.
- Priority sorting was silently a no-op on a store whose catalog is virtual: the facet came back in
  raw index order, with no error and nothing in the log. Dictionary priorities configured on the
  linked catalogs now take effect.
- A facet value with no dictionary item has no priority, and now sorts last in both directions rather
  than being treated as priority `0`.

No schema change, no migrations, no new settings, no new dependencies. The sorting type remains a
free-form string inside the store's existing `FilteredBrowsing` setting, in both the JSON and the
legacy XML form.

No companion PR in another repository.

## New GraphQL queries and mutations

None — this module has no `ExperienceApi` project and this PR adds no query or mutation.

## Changes to existing GraphQL queries and mutations

None — no schema change.

One value-domain change to be aware of: the `termValuesSortingType` carried on a product facet can now
hold two additional strings, `PriorityAscending` and `PriorityDescending`. It is a plain `string` at
every layer of this module, so nothing here constrains it. If a downstream xAPI or client project maps
that field onto a GraphQL enum or a closed union, add the two values there before upgrading.

## New public services / interfaces / methods

Two constants on `VirtoCommerce.CatalogModule.Core.ModuleConstants`, for setting a store facet's
sorting type from code:

- `TermValuesSortingTypePriorityAscending` (`"PriorityAscending"`) — lowest priority value first.
- `TermValuesSortingTypePriorityDescending` (`"PriorityDescending"`) — highest priority value first.

`TermValuesSortingTypePriority` (`"Priority"`) is retained and now behaves as
`TermValuesSortingTypePriorityAscending`.

No new service, interface or method.

## New protected methods (extensibility)

None. The methods that changed are all `private`, as they were before, and the existing
`protected virtual` surface of `AggregationConverter` is untouched — including
`ConvertAggregationsAsync` and `AddLabelsAsync`, which remain the seams for customising facet
conversion.

## Breaking changes

**Nothing breaks at compile time.** No public or protected member changed signature or was removed. The
two methods whose signatures changed are `private`.

**Nothing breaks on package upgrade.** `ModuleConstants.TermValuesSortingTypePriority` is kept, as is
the `sorting-type-labels.priority` localisation key. Persisted store configuration holding `Priority`
still deserializes, from both the JSON and the legacy XML format.

**Facet value order changes at runtime, with no warning.** This is the defect being fixed, so it is
intended, but it lands on stores that were never touched and it is visible on the storefront:

- A store configured to sort a facet by priority now renders **ascending** where it previously
  rendered descending. To keep the previous order, select **Priority descending** on that facet.
- A store whose catalog is virtual now actually sorts by priority, where the setting previously did
  nothing. Facets there move from raw index order into priority order.
- Facet values with no dictionary item move to the end of the list.

No `[Obsolete]` was introduced. `TermValuesSortingTypePriority` is deliberately *not* marked obsolete:
it is a persisted data value, not only a code symbol, so it has to keep deserializing indefinitely for
stores configured before this change. It is removed from the admin dropdown only.

## New dependencies

None.

> **Note (why legacy `Priority` means ascending)** — the value is ambiguous by construction, so one of
> the two directions had to be chosen for it. Ascending is the direction the admin UI has always
> documented for the field it sorts by ("The lowest value will be used first"), which makes descending
> the defect rather than the contract. Reading it as descending would have preserved the buggy order
> and left no configuration that honours the documented one.

> **Note (why the virtual-catalog case was silent)** — for a virtual catalog,
> `GetAllCatalogPropertiesAsync` returns one property per linked catalog, so several share the name
> `Color` or `Brand`. The old code resolved that name to a single property and then read only that
> property's dictionary items; when the resolved one was not the property carrying the priorities, the
> lookup missed and the loop skipped the facet without sorting or logging. Dictionary items are now
> merged across every same-named property, which is what the neighbouring
> `TryAddLabelsAsyncForProperty` already did for labels.

> **Note (duplicate aliases across linked catalogs)** — when the same alias arrives from several
> same-named properties, the strongest priority that was actually set wins, and the default `0` is
> treated as "not set" while any duplicate carries an explicit value. Without that rule a linked
> catalog whose dictionary is left at the default would cancel out the priorities configured on
> another. Behaviour is unchanged where an alias appears once, which is every non-virtual catalog.

> **Note (case sensitivity, pre-existing)** — the sorting type is matched exactly, so a value
> hand-edited into the store setting with different casing falls through to unsorted. That has been
> true of all sorting types since term values sorting was introduced and is unchanged here.

## References
### QA-test:
On a store whose catalog is physical:
1. Catalog → a dictionary property (for example `Color`) → set distinct priorities on three values,
   for example `1`, `11`, `13`.
2. Stores → the store → Facets → that property → Sorting = **Priority ascending** → OK → Save.
3. Storefront search page → expand that filter. Expected: the value with priority `1` first, `13`
   last. Selecting **Priority descending** reverses it.
4. Set a fourth facet value that has no dictionary item. Expected: it appears last in both directions.

Repeat step 2 on a store whose catalog is virtual, with the property priorities configured on a linked
catalog. Expected: the facet is ordered by those priorities. Before this change it stayed in raw index
order, ordered by document count.

Upgrade check: a store configured with the old **Priority** setting needs no reconfiguration — its
facet order flips to lowest-value-first, and the admin dropdown shows **Priority ascending**.

### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5851

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Catalog_3.1044.0-pr-906-60be.zip


## References
### QA-test:
### Jira-link:
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Storefront facet order changes for existing priority-sorted facets (ascending vs former descending behavior) and virtual catalogs that previously did not sort; no auth or schema migration, but visible merchandising impact.
> 
> **Overview**
> **Facet dictionary priority sorting** now honors ascending vs descending, fixes incorrect order, and works for virtual catalogs.
> 
> Store facet **Sorting** gains **Priority ascending** and **Priority descending** (`PriorityAscending` / `PriorityDescending` on `ModuleConstants`); legacy persisted **`Priority`** is treated as ascending and the admin blade maps it to **Priority ascending** on open. `AggregationConverter` defers priority sorts with a direction flag, sorts lowest `SortOrder` first (or reversed), puts facet values **without** a dictionary item **last**, and **merges dictionary priorities across all same-named properties** (virtual catalogs) instead of picking one property id.
> 
> Locales add the two new sorting labels; tests cover directions, legacy config, virtual-catalog duplicates, and store setting round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60be3c074f7b22c470242a33d54d7cdef5362f5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->